### PR TITLE
deleted fancyBorder: false to show overlay media widget's border

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/overlay/media/MediaContent.qml
+++ b/dots/.config/quickshell/ii/modules/ii/overlay/media/MediaContent.qml
@@ -22,7 +22,6 @@ StyledOverlayWidget {
     minimumHeight: 150
     
     readonly property MprisPlayer currentPlayer: MprisController.activePlayer
-    fancyBorders: false
     
     property bool downloaded: false
     property string displayedArtFilePath: root.downloaded ? Qt.resolvedUrl(artFilePath) : ""


### PR DESCRIPTION
## Describe your changes

Deleted `fancyBorder: false` line to show overlay media widget's border


