### PR TITLE
fix(searchbar): tooltip going outside the screen when bar is not on top

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/overview/SearchBar.qml
+++ b/dots/.config/quickshell/ii/modules/ii/overview/SearchBar.qml
@@ -117,7 +117,7 @@ RowLayout {
         text: "image_search"
         StyledToolTip {
             text: Translation.tr("Google Lens")
-            y: !Config?.options.bar.top ? parent.height + 5 : undefined
+            y: parent.height + 3
         }
     }
 
@@ -140,7 +140,7 @@ RowLayout {
 
         StyledToolTip {
             text: Translation.tr("Recognize music")
-            y: !Config?.options.bar.top ? parent.height + 5 : undefined
+            y: parent.height + 3
         }
 
         colText: toggled ? Appearance.colors.colOnPrimary : Appearance.colors.colOnSurfaceVariant


### PR DESCRIPTION
## Describe your changes

The tooltip on google lens and recognize music buttons in search bar is outside the screen when bar is not on top, this pr forces it to appear below the buttons.

## Is it ready? Questions/feedback needed?

I guess there are more elegant solutions for this, but it works

