### PR TITLE
feat(osd): Adding volume osd for current player

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/onScreenDisplay/OnScreenDisplay.qml
+++ b/dots/.config/quickshell/ii/modules/ii/onScreenDisplay/OnScreenDisplay.qml
@@ -25,6 +25,10 @@ Scope {
             id: "brightness",
             sourceUrl: "indicators/BrightnessIndicator.qml"
         },
+        {
+            id: "playerVolume",
+            sourceUrl: "indicators/PlayerVolumeIndicator.qml"
+        },
     ]
 
     function triggerOsd() {
@@ -76,6 +80,17 @@ Scope {
             root.protectionMessage = reason;
             root.currentIndicator = "volume";
             root.triggerOsd();
+        }
+    }
+
+    Connections {
+        // Listen to MPRIS/MPD media player volume changes
+        target: MprisController.activePlayer ?? null
+        function onVolumeChanged() {
+            if (MprisController.canChangeVolume) {
+                root.currentIndicator = "playerVolume";
+                root.triggerOsd();
+            }
         }
     }
 

--- a/dots/.config/quickshell/ii/modules/ii/onScreenDisplay/indicators/PlayerVolumeIndicator.qml
+++ b/dots/.config/quickshell/ii/modules/ii/onScreenDisplay/indicators/PlayerVolumeIndicator.qml
@@ -1,0 +1,12 @@
+import qs.services
+import QtQuick
+import qs.modules.ii.onScreenDisplay
+import qs.modules.common.widgets
+
+OsdValueIndicator {
+    id: osdValues
+    value: MprisController.activePlayer?.volume ?? 0
+    icon: "music_note"
+    name: Translation.tr("Music")
+    shape: MaterialShape.Shape.Cookie4Sided
+}


### PR DESCRIPTION
## Describe your changes
Adding volume osd for current player

only works if the volume change is exposed to mpris
<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?
Yes. Tested on mpd and spotify. 

