### PR TITLE
feat(sounds): Add sound option to Microphone mute/unmute

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -684,6 +684,7 @@ Singleton {
 
             property JsonObject sounds: JsonObject {
                 property bool battery: false
+                property bool micMute: false
                 property bool pomodoro: false
                 property string theme: "freedesktop"
             }

--- a/dots/.config/quickshell/ii/modules/settings/GeneralConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/GeneralConfig.qml
@@ -325,6 +325,14 @@ ContentPage {
                 }  
             }  
             ConfigSwitch {  
+                buttonIcon: "mic"  
+                text: Translation.tr("Microphone")  
+                checked: Config.options.sounds.micMute  
+                onCheckedChanged: {  
+                    Config.options.sounds.micMute = checked;  
+                }  
+            }  
+            ConfigSwitch {  
                 buttonIcon: "av_timer"  
                 text: Translation.tr("Pomodoro")  
                 checked: Config.options.sounds.pomodoro  

--- a/dots/.config/quickshell/ii/services/Audio.qml
+++ b/dots/.config/quickshell/ii/services/Audio.qml
@@ -57,6 +57,11 @@ Singleton {
         Audio.source.audio.muted = !Audio.source.audio.muted
     }
 
+    function playMicMuteSound(muted) {
+        if (!Config.options.sounds.micMute) return;
+        Audio.playSystemSound(muted ? "device-removed" : "device-added")
+    }
+
     function incrementVolume() {
         const currentVolume = Audio.value;
         const step = currentVolume < 0.1 ? 0.01 : 0.02 || 0.2;
@@ -80,6 +85,13 @@ Singleton {
     // Internals
     PwObjectTracker {
         objects: [sink, source]
+    }
+
+    Connections {
+        target: source?.audio ?? null
+        function onMutedChanged() {
+            root.playMicMuteSound(source.audio.muted)
+        }
     }
 
     Connections { // Protection against sudden volume changes


### PR DESCRIPTION
## Describe your changes
Adding sound option to Microphone mute/unmute. uses mic state so it works with quickshell bar/sidebar buttons, keybinds and scripts etc. uses freedesktop sounds no additional files
<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?
Yes

