### PR TITLE
fix(lockscreen): close overlay before locking the screen

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/panels/lock/LockScreen.qml
+++ b/dots/.config/quickshell/ii/modules/common/panels/lock/LockScreen.qml
@@ -52,6 +52,9 @@ Scope {
             target: GlobalStates
             function onScreenLockedChanged() {
                 if (GlobalStates.screenLocked) {
+                    if (GlobalStates.overlayOpen) {
+                        GlobalStates.overlayOpen = false;
+                    }
                     lockContext.reset();
                     lockContext.tryFingerUnlock();
                 }


### PR DESCRIPTION
## Describe your changes

If locking the screen while on overlay the overlay was on the same layer as the lockscreen. With this pr it closes the overlay if open when locking the screen.

## Is it ready? Questions/feedback needed?

I think it's okay i don't know if there is a better way, maybe changing layers priority in hyprland is another approach

