### PR TITLE
fix(osd): wrapped material icon moving around

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/onScreenDisplay/OsdValueIndicator.qml
+++ b/dots/.config/quickshell/ii/modules/ii/onScreenDisplay/OsdValueIndicator.qml
@@ -52,8 +52,8 @@ Item {
                 MaterialShapeWrappedMaterialSymbol {
                     rotation: root.value * 360
                     anchors {
-                        centerIn: parent
-                        alignWhenCentered: !root.rotateIcon
+                        fill: parent
+                        margins: -5
                     }
                     iconSize: Appearance.font.pixelSize.huge
                     shape: root.shape


### PR DESCRIPTION
## Describe your changes

The material icon moves around a little bit when changing value. This is one way i found to fix it in place

## Is it ready? Questions/feedback needed?

It is ready, i don't know if the negative margins is the best approach, i tried other things but this is the only one that worked.

Also i wanted to discuss the animation of the styledtext of the osd values. I think it looks better without animation as the current animation makes the number disappear. 
I didn't include the change in this commit as it's personal taste and maybe you like it better that way. The same goes for the animation of the numbers in the new settings search function (es. 11/14), even if i think there it's a bit more fitting. But it's your call of course.


