### PR TITLE
fix(mediawidget): maybe this can help solve issue #22

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/background/widgets/media/MediaWidget.qml
+++ b/dots/.config/quickshell/ii/modules/ii/background/widgets/media/MediaWidget.qml
@@ -28,8 +28,20 @@ AbstractBackgroundWidget {
     readonly property bool showRestButtons: hideAllButtons ? hovering : true
 
     readonly property var playerList: MprisController.players
-    property var filteredPlayerList: playerList.filter(player => player != null && player.trackAlbum != "")
-    property var filteredActivePlayer: MprisController.activePlayer?.trackAlbum != "" ? MprisController.activePlayer : null
+
+    property var filteredPlayerList: playerList.filter(player => 
+        player != null && 
+        (player.trackTitle != null && player.trackTitle !== "")  
+    )
+    
+    property var filteredActivePlayer: {
+        let active = MprisController.activePlayer;
+        if (active && active.trackTitle && active.trackTitle !== "") {
+            return active;
+        }
+
+        return filteredPlayerList.length > 0 ? filteredPlayerList[0] : null;
+    }
     
     property MprisPlayer currentPlayer : filteredActivePlayer
     property var artUrl: currentPlayer?.trackArtUrl


### PR DESCRIPTION
## Describe your changes

I did use ai, says the media widget was filtering players by trackAlbum. 
This change makes the media widget work again for me. I didn't test spotify tho.
Maybe this can offer some hint to solve the issue idk.

Issues i noticed:
- YouTube video's covers don't load or they flash and disappears, they often load after i stop and play again the video. This issue is present also in the bar media widget.

