### PR TITLE
feat(bar): Add cpu temperature and frequency

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/bar/ResourcesPopup.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/ResourcesPopup.qml
@@ -88,6 +88,16 @@ StyledPopup {
                     label: Translation.tr("Load:")
                     value: `${Math.round(ResourceUsage.cpuUsage * 100)}%`
                 }
+                StyledPopupValueRow {
+                    icon: "speed"
+                    label: Translation.tr("Freq:")
+                    value: ResourceUsage.cpuCurrentFreqString
+                }
+                StyledPopupValueRow {
+                    icon: "device_thermostat"
+                    label: Translation.tr("Temp:")
+                    value: ResourceUsage.cpuTemperatureString
+                }
             }
         }
     }


### PR DESCRIPTION
## Describe your changes
Added cpu temperature and frequency in ResourcesPopup.

Using `scaling_cur_freq` makes the shown frequency match the actual per‑core DVFS state instead of static specs from /proc/cpuinfo.

Using `sensors -j + jq` with multiple fallback keys makes temperature detection more robust across Intel/AMD and different lm‑sensors configurations.

All new data flows through the existing ResourceUsage singleton, so other UIs can reuse CPU freq / temp if needed.

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?
Yes, from what I’ve tested. Needs review cuz I did use AI.

