### PR TITLE
remove osd value number animation

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/onScreenDisplay/OsdValueIndicator.qml
+++ b/dots/.config/quickshell/ii/modules/ii/onScreenDisplay/OsdValueIndicator.qml
@@ -82,10 +82,7 @@ Item {
                         Layout.fillWidth: false
                         Layout.preferredWidth: 30
                         horizontalAlignment: Text.AlignRight
-                        text: Math.round(root.value * 100)
-                        animateChange: true
-                        animationDistanceY: 2 // for faster animation than default
-                        
+                        text: Math.round(root.value * 100)                        
                     }
                 }
                 


### PR DESCRIPTION
## Describe your changes

This pr removes the osd value number animation, i tried to replicate the subtle animation that it's present in material design 3 but without success, so this just removes the animation. 

## Is it ready? Questions/feedback needed?

If you think it's better than the current animation