### PR TITLE
fix(IdleInhibitor): Making IdleInhibitor only persist per hyprland session not after reboot/logout

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Persistent.qml
+++ b/dots/.config/quickshell/ii/modules/common/Persistent.qml
@@ -85,6 +85,7 @@ Singleton {
 
             property JsonObject idle: JsonObject {
                 property bool inhibit: false
+                property string sessionId: ""
             }
 
             property JsonObject overlay: JsonObject {

--- a/dots/.config/quickshell/ii/modules/common/panels/lock/LockScreen.qml
+++ b/dots/.config/quickshell/ii/modules/common/panels/lock/LockScreen.qml
@@ -12,6 +12,13 @@ import Quickshell.Hyprland
 Scope {
     id: root
 
+    // Ensure Idle service is always loaded so the idle inhibitor works in both panel families
+    // (e.g. even when "Keep right sidebar loaded" is off in ii).
+    Item {
+        id: idleServiceAnchor
+        property bool _ensureIdleLoaded: Idle.inhibit
+    }
+
     required property Component lockSurface
     property alias context: lockContext
     property Component sessionLockSurface: WlSessionLockSurface {
@@ -144,6 +151,9 @@ Scope {
             KeyringStorage.fetchKeyringData();
         }
     }
+
+    Component.onCompleted: initIfReady()
+
     Connections {
         target: Config
         function onReadyChanged() {


### PR DESCRIPTION
## Describe your changes
Fixes the idle inhibitor to work correctly regardless of the "Keep right sidebar loaded" setting and changes state persistence to only restore on shell reload/restart (not after logout/reboot).

## Problems Fixed

### 1. Idle inhibitor not working when sidebar isn't kept loaded
**Issue**: When "Keep right sidebar loaded" was disabled, the idle inhibitor toggle appeared active in the UI but the system would still go idle. This happened because the `Idle` singleton was only created when the sidebar content was loaded, so the Wayland idle inhibitor wasn't actually active.

**Solution**: Added an anchor item in `LockScreen.qml` that references `Idle.inhibit` to ensure the Idle service singleton is always created when the lock screen loads. Since `LockScreen` is used by both panel families (`ii` and `waffle`) and loads before the sidebar, this guarantees the idle inhibitor is available when needed.

~~### 2. State persisting across reboots/logouts
**Issue**: The idle inhibitor state was being restored after every reboot or logout, which wasn't desired behavior. and was not relibale as the idle inhibitor toggle appeared active in the UI. but the system would still go idle some times~~

~~**Solution**: Quickshell.env("HYPRLAND_INSTANCE_SIGNATURE") to detect new vs reloaded sessions, eliminating the async process and its race condition. Adds a deferred Timer with interval: 0 to ensure the JSON adapter is fully populated before reading from it.~~

### 3. Lock screen "launch on startup" broken
**Issue**: After adding the Idle anchor, the lock screen's "launch on startup" feature stopped working because `Persistent` could become ready before `LockScreen` was created, causing the initialization logic to never run.

**Solution**: Added `Component.onCompleted: initIfReady()` to `LockScreen.qml` so initialization runs both when Config/Persistent become ready (via Connections) and when the component is created (handling the case where both are already ready).


<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?
Yes.

