### PR TITLE
fix(Translator): add `-no-bidi` flag to translation process

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/sidebarPolicies/Translator.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarPolicies/Translator.qml
@@ -63,7 +63,7 @@ Item {
 
     Process {
         id: translateProc
-        command: ["bash", "-c", `trans -brief`
+        command: ["bash", "-c", `trans -brief -no-bidi`
             + ` -source '${StringUtils.shellSingleQuoteEscape(root.sourceLanguage)}'`
             + ` -target '${StringUtils.shellSingleQuoteEscape(root.targetLanguage)}'`
             + ` '${StringUtils.shellSingleQuoteEscape(root.inputField.text.trim())}'`]


### PR DESCRIPTION
## Describe your changes
RTL languages were rendering backwards in the translation output. This was caused by `trans` outputting visually pre-reversed text intended for BiDi-unaware terminals, while Qt's text engine expects logical Unicode order and handles BiDi rendering itself.

Fixes this by passing `-no-bidi` to `translateProc`, consistent with how `getLanguagesProc` already calls `trans -list-languages -no-bidi`.

<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?
Yes.
