### PR TITLE
feat(dock): unload dock when hidden

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -444,7 +444,7 @@ Singleton {
                 property real hoverRegionHeight: 2
                 property bool pinnedOnStartup: false
                 property bool enablePreview: true
-                property bool hoverToReveal: true
+                property bool revealOnEmptyWorkspace: true
                 property bool enableMediaWidget: false
                 property string position: "bottom"
                 property list<string> pinnedApps: [

--- a/dots/.config/quickshell/ii/modules/ii/dock/Dock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/dock/Dock.qml
@@ -140,7 +140,7 @@ Scope {
             // hover trigger, giving the user time to reach the dock as it expands.
             Timer {
                 id: graceTimer
-                interval: 1000
+                interval: Appearance.animation.elementMoveFast.duration + 800 
                 onRunningChanged: dockRoot.updateReveal()
             }
 

--- a/dots/.config/quickshell/ii/modules/ii/dock/Dock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/dock/Dock.qml
@@ -37,15 +37,19 @@ Scope {
         const maxW = Math.max(1, opts.availableW - gapsOut * 2 - barOffsetH)
         const maxH = Math.max(1, opts.availableH - gapsOut * 2 - barOffset)
 
-        const contentW = opts.contentVisualWidth + opts.dockPadding * 2
-        const contentH = opts.contentVisualHeight + opts.dockPadding * 2
+        const unloadedW = 1000
+        const unloadedH = 1000
+
+        const contentW = opts.isLoaded ? opts.contentVisualWidth : (opts.isVertical ? 60 : unloadedW)
+        const contentH = opts.isLoaded ? opts.contentVisualHeight : (opts.isVertical ? unloadedH : 60)
+        const dockPadding = opts.isLoaded ? opts.dockPadding : 0
 
         return {
             maxWidth: maxW,
             maxHeight: maxH,
-            dockWidth:     opts.isVertical ? contentW + gapsOut * 2 : Math.min(contentW + gapsOut * 2, maxW),
-            dockHeight:    opts.isVertical ? Math.min(contentH + gapsOut * 2, maxH) : contentH + gapsOut * 2,
-            dockThickness: opts.isVertical ? contentW + gapsOut * 2 : contentH + gapsOut * 2,
+            dockWidth:     opts.isVertical ? contentW + dockPadding * 2 + gapsOut * 2 : Math.min(contentW + dockPadding * 2 + gapsOut * 2, maxW),
+            dockHeight:    opts.isVertical ? Math.min(contentH + dockPadding * 2 + gapsOut * 2, maxH) : contentH + dockPadding * 2 + gapsOut * 2,
+            dockThickness: opts.isVertical ? contentW + dockPadding * 2 + gapsOut * 2 : contentH + dockPadding * 2 + gapsOut * 2,
             backgroundWidth:  Math.max(1, opts.isVertical ? contentW : Math.min(contentW, maxW - gapsOut * 2)),
             backgroundHeight: Math.max(1, opts.isVertical ? Math.min(contentH, maxH - gapsOut * 2) : contentH)
         }
@@ -66,11 +70,12 @@ Scope {
             readonly property real availableH: screen?.height ?? 1080
             readonly property bool barActive: GlobalStates.barOpen
             readonly property bool barIsVertical: Config.options?.bar?.vertical ?? false
-            readonly property real barThickness: barActive? (barIsVertical ? (Config.options?.bar?.sizes?.width ?? Appearance.sizes.verticalBarWidth) : (Config.options?.bar?.sizes?.height ?? Appearance.sizes.barHeight)) : 0
+            readonly property real barThickness: barActive ? (barIsVertical ? (Config.options?.bar?.sizes?.width ?? Appearance.sizes.verticalBarWidth) : (Config.options?.bar?.sizes?.height ?? Appearance.sizes.barHeight)) : 0
 
             readonly property bool isVertical: dock.isVertical
             readonly property real dockThickness: isVertical ? dockRoot.sizing.dockWidth : dockRoot.sizing.dockHeight
-            property bool reveal: dock.pinned || (Config.options?.dock.hoverToReveal && dockMouseArea.containsMouse) || (dockContent.requestDockShow) || (workspaceEmpty)
+            
+            property bool reveal: dock.pinned || (Config.options?.dock.hoverToReveal && dockMouseArea.containsMouse) || (dockLoader.item?.requestDockShow ?? false) || (workspaceEmpty)
             property bool positionChanging: false
 
             // TODO: check for multi-monitor situations
@@ -83,14 +88,15 @@ Scope {
             readonly property var sizing: dock.computeSizes({
                 gapsOut: Appearance.sizes.hyprlandGapsOut,
                 isVertical: dock.isVertical,
-                barActive: barActive,
-                barIsVertical: barIsVertical,
-                barThickness: barThickness,
-                availableW: availableW,
-                availableH: availableH,
-                contentVisualWidth: dockContent.visualWidth,
-                contentVisualHeight: dockContent.visualHeight,
-                dockPadding: dockContent.dockPadding
+                barActive: dockRoot.barActive,
+                barIsVertical: dockRoot.barIsVertical,
+                barThickness: dockRoot.barThickness,
+                availableW: dockRoot.availableW,
+                availableH: dockRoot.availableH,
+                isLoaded: dockLoader.activeAsync,
+                contentVisualWidth: dockLoader.item?.contentVisualWidth ?? 0,
+                contentVisualHeight: dockLoader.item?.contentVisualHeight ?? 0,
+                dockPadding: dockLoader.item?.dockPadding ?? 0
             })
 
             implicitWidth: Math.max(1, dockRoot.sizing.dockWidth)
@@ -108,14 +114,18 @@ Scope {
             WlrLayershell.layer: WlrLayer.Overlay
             color: "transparent"
 
-            mask: Region {
-                item: dockMouseArea
+            mask: Region { 
+                item: dockMouseArea 
             }
 
-            Timer {
-                id: positionChangeTimer
-                interval: 200
-                onTriggered: dockRoot.positionChanging = false
+            Timer { 
+                id: unloadTimer
+                interval: Appearance.animation.elementMoveFast.duration + 100 
+            }
+
+            onRevealChanged: {
+                if (!reveal) unloadTimer.restart()
+                else unloadTimer.stop()
             }
 
             Connections {
@@ -126,13 +136,21 @@ Scope {
                 }
             }
 
+            Timer {
+                id: positionChangeTimer
+                interval: 200
+                onTriggered: dockRoot.positionChanging = false
+            }
+
             HyprlandFocusGrab {
                 id: dragFocusGrab
-                active: dockContent.dragState != "idle"
+                active: dockLoader.activeAsync && (dockLoader.item?.dragState ?? "idle") !== "idle"
                 windows: [dockRoot]
                 onCleared: {
-                    if (dockContent.isAppDrag) dockContent.endDrag()
-                    if (dockContent.isFileDrag) dockContent.endFileDrag()
+                    if (dockLoader.item && dockLoader.item.dragState !== "idle") {
+                        dockLoader.item.endDrag()
+                        dockLoader.item.endFileDrag()
+                    }
                 }
             }
 
@@ -177,72 +195,81 @@ Scope {
                 Behavior on anchors.leftMargin { animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(dockMouseArea) }
                 Behavior on anchors.rightMargin { animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(dockMouseArea) }
 
-                StyledRectangularShadow { target: dockVisualBackground }
+                Item {
+                    id: dockContentHost
+                    anchors.fill: parent
 
-                Rectangle {
-                    id: dockVisualBackground
-                    anchors.centerIn: parent
+                    LazyLoader {
+                        id: dockLoader
+                        loading: true
+                        active: dockRoot.reveal || unloadTimer.running
 
-                    width: dockRoot.sizing.backgroundWidth
-                    height: dockRoot.sizing.backgroundHeight
+                        Item {
+                            id: wrapper
+                            parent: dockContentHost
+                            anchors.fill: parent
 
-                    color: Appearance.colors.colLayer0
-                    border.width: 1
-                    border.color: Appearance.colors.colLayer0Border
-                    radius: Appearance.rounding.large
+                            readonly property real contentVisualWidth: content.visualWidth
+                            readonly property real contentVisualHeight: content.visualHeight
+                            readonly property real dockPadding: content.dockPadding
+                            readonly property string dragState: content.dragState
+                            readonly property bool requestDockShow: content.requestDockShow
+                            
+                            function endDrag() { content.endDrag() }
+                            function endFileDrag() { content.endFileDrag() }
+                            function mimeIconFromPath(p) { return content.mimeIconFromPath(p) }
 
-                    DropArea {
-                        id: fileDropArea
-                        anchors.fill: parent
-                        keys: ["text/uri-list"]
+                            opacity: (dockLoader.activeAsync && !dockRoot.positionChanging) ? 1.0 : 0.0
+                            Behavior on opacity { NumberAnimation { duration: 150 } }
 
-                        // We delay the re-enablement slightly after an internal drag ends
-                        // to prevent the "exited" event from firing for the internal drag.
-                        property bool blockDueToInternal: dockContent.dragActive
-                        onBlockDueToInternalChanged: {
-                            if (!blockDueToInternal) {
-                                reEnableTimer.restart()
-                            } else {
-                                enabled = false
+                            StyledRectangularShadow { 
+                                target: visualBackground
                             }
-                        }
 
-                        Timer {
-                            id: reEnableTimer
-                            interval: 50
-                            onTriggered: fileDropArea.enabled = true
-                        }
+                            Rectangle {
+                                id: visualBackground
+                                anchors.centerIn: parent
+                                width: dockRoot.sizing.backgroundWidth
+                                height: dockRoot.sizing.backgroundHeight
+                                color: Appearance.colors.colLayer0
+                                border.width: 1
+                                border.color: Appearance.colors.colLayer0Border
+                                radius: Appearance.rounding.large
 
-                        onEntered: (drag) => {
-                            if (!drag.hasUrls) return
-                            //console.log("[Dock] External drag entered")
-                            const url = drag.urls[0]?.toString() ?? ""
-                            dockContent.externalDragIcon = dockContent.mimeIconFromPath(url)
-                            dockContent.externalDragOver = true
-                        }
-                        onExited: {
-                            //console.log("[Dock] External drag exited")
-                            dockContent.externalDragIcon = ""
-                            dockContent.externalDragOver = false
-                        }
-                        onDropped: (drop) => {
-                            if (!drop.hasUrls) return
-                            //console.log("[Dock] External drag dropped")
-                            for (let i = 0; i < drop.urls.length; i++)
-                                TaskbarApps.addPinnedFile(drop.urls[i])
-                            drop.accept(Qt.CopyAction)
-                            dockContent.externalDragIcon = ""
-                            dockContent.externalDragOver = false
-                        }
-                    }
+                                DropArea {
+                                    id: fileDropArea
+                                    anchors.fill: parent
+                                    keys: ["text/uri-list"]
+                                    enabled: content.dragActive === false
 
-                    DockContent {
-                        id: dockContent
-                        anchors.fill: parent
-                        isPinned: dock.pinned
-                        currentScreen: dockRoot.screen
-                        onTogglePinRequested: {
-                            dock.pinned = !dock.pinned
+                                    onEntered: (drag) => {
+                                        if (!drag.hasUrls) return
+                                        const url = drag.urls[0]?.toString() ?? ""
+                                        content.externalDragIcon = content.mimeIconFromPath(url)
+                                        content.externalDragOver = true
+                                    }
+                                    onExited: {
+                                        content.externalDragIcon = ""
+                                        content.externalDragOver = false
+                                    }
+                                    onDropped: (drop) => {
+                                        if (!drop.hasUrls) return
+                                        for (let i = 0; i < drop.urls.length; i++)
+                                            TaskbarApps.addPinnedFile(drop.urls[i])
+                                        drop.accept(Qt.CopyAction)
+                                        content.externalDragIcon = ""
+                                        content.externalDragOver = false
+                                    }
+                                }
+
+                                DockContent {
+                                    id: content
+                                    anchors.fill: parent
+                                    isPinned: dock.pinned
+                                    currentScreen: dockRoot.screen
+                                    onTogglePinRequested: dock.pinned = !dock.pinned
+                                }
+                            }
                         }
                     }
                 }

--- a/dots/.config/quickshell/ii/modules/ii/dock/Dock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/dock/Dock.qml
@@ -37,8 +37,8 @@ Scope {
         const maxW = Math.max(1, opts.availableW - gapsOut * 2 - barOffsetH)
         const maxH = Math.max(1, opts.availableH - gapsOut * 2 - barOffset)
 
-        const unloadedW = 1000
-        const unloadedH = 1000
+        const unloadedW = maxW
+        const unloadedH = maxH
 
         const contentW = opts.isLoaded ? opts.contentVisualWidth : (opts.isVertical ? 60 : unloadedW)
         const contentH = opts.isLoaded ? opts.contentVisualHeight : (opts.isVertical ? unloadedH : 60)
@@ -47,8 +47,8 @@ Scope {
         return {
             maxWidth: maxW,
             maxHeight: maxH,
-            dockWidth:     opts.isVertical ? contentW + dockPadding * 2 + gapsOut * 2 : Math.min(contentW + dockPadding * 2 + gapsOut * 2, maxW),
-            dockHeight:    opts.isVertical ? Math.min(contentH + dockPadding * 2 + gapsOut * 2, maxH) : contentH + dockPadding * 2 + gapsOut * 2,
+            dockWidth: opts.isVertical ? contentW + dockPadding * 2 + gapsOut * 2 : Math.min(contentW + dockPadding * 2 + gapsOut * 2, maxW),
+            dockHeight: opts.isVertical ? Math.min(contentH + dockPadding * 2 + gapsOut * 2, maxH) : contentH + dockPadding * 2 + gapsOut * 2,
             dockThickness: opts.isVertical ? contentW + dockPadding * 2 + gapsOut * 2 : contentH + dockPadding * 2 + gapsOut * 2,
             backgroundWidth:  Math.max(1, opts.isVertical ? contentW : Math.min(contentW, maxW - gapsOut * 2)),
             backgroundHeight: Math.max(1, opts.isVertical ? Math.min(contentH, maxH - gapsOut * 2) : contentH)
@@ -75,7 +75,7 @@ Scope {
             readonly property bool isVertical: dock.isVertical
             readonly property real dockThickness: isVertical ? dockRoot.sizing.dockWidth : dockRoot.sizing.dockHeight
             
-            property bool reveal: dock.pinned || (Config.options?.dock.hoverToReveal && dockMouseArea.containsMouse) || (dockLoader.item?.requestDockShow ?? false) || (workspaceEmpty)
+            property bool reveal: dock.pinned || (Config.options?.dock.hoverToReveal && (dockMouseArea.containsMouse || graceTimer.running)) || (dockLoader.item?.requestDockShow ?? false) || (workspaceEmpty)
             property bool positionChanging: false
 
             // TODO: check for multi-monitor situations
@@ -123,6 +123,13 @@ Scope {
                 interval: Appearance.animation.elementMoveFast.duration + 100 
             }
 
+            // Grace timer: keeps the dock revealed for 1 second after the initial
+            // hover trigger, giving the user time to reach the dock as it expands.
+            Timer {
+                id: graceTimer
+                interval: 1000
+            }
+
             onRevealChanged: {
                 if (!reveal) unloadTimer.restart()
                 else unloadTimer.stop()
@@ -157,6 +164,15 @@ Scope {
             MouseArea {
                 id: dockMouseArea
                 hoverEnabled: true
+
+                // When the mouse enters the hover strip and the dock is hidden,
+                // start the grace timer so the dock stays open for 1 second while
+                // it animates and the user moves the cursor onto it.
+                onContainsMouseChanged: {
+                    if (containsMouse && !dockRoot.reveal && !dock.pinned) {
+                        graceTimer.restart()
+                    }
+                }
 
                 property real hiddenOffset: dockRoot.dockThickness - (Config.options?.dock.hoverRegionHeight ?? 10)
                 property real fullyHiddenOffset: dockRoot.dockThickness + 1

--- a/dots/.config/quickshell/ii/modules/ii/dock/Dock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/dock/Dock.qml
@@ -82,9 +82,9 @@ Scope {
 
             function updateReveal() {
                 var shouldReveal = dock.pinned
-                    || (Config.options?.dock.hoverToReveal && (dockMouseArea.containsMouse || graceTimer.running))
+                    || (dockMouseArea.containsMouse || graceTimer.running)
                     || (dockLoader.item?.requestDockShow ?? false)
-                    || workspaceEmpty
+                    || (Config.options?.dock?.revealOnEmptyWorkspace && workspaceEmpty)
                 if (reveal !== shouldReveal)
                     reveal = shouldReveal
             }
@@ -192,9 +192,8 @@ Scope {
                     dockRoot.updateReveal()
                 }
 
-                property real hiddenOffset: dockRoot.dockThickness - (Config.options?.dock.hoverRegionHeight ?? 10)
-                property real fullyHiddenOffset: dockRoot.dockThickness + 1
-                property real currentOffset: dockRoot.readyToReveal ? 0 : (Config.options?.dock.hoverToReveal ? hiddenOffset : fullyHiddenOffset)
+                property real hiddenOffset: dockRoot.dockThickness - (Config.options?.dock.hoverRegionHeight ?? 2)
+                property real currentOffset: dockRoot.readyToReveal ? 0 : hiddenOffset
 
                 width: dock.isVertical ? dockRoot.dockThickness : dockRoot.sizing.dockWidth
                 height: dock.isVertical ? dockRoot.sizing.dockHeight : dockRoot.dockThickness

--- a/dots/.config/quickshell/ii/modules/ii/dock/Dock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/dock/Dock.qml
@@ -74,9 +74,20 @@ Scope {
 
             readonly property bool isVertical: dock.isVertical
             readonly property real dockThickness: isVertical ? dockRoot.sizing.dockWidth : dockRoot.sizing.dockHeight
-            
-            property bool reveal: dock.pinned || (Config.options?.dock.hoverToReveal && (dockMouseArea.containsMouse || graceTimer.running)) || (dockLoader.item?.requestDockShow ?? false) || (workspaceEmpty)
+
+            // reveal is set imperatively (not as a binding) to avoid a binding loop:
+            property bool reveal: false
             property bool positionChanging: false
+            readonly property bool readyToReveal: reveal && (dockLoader.item?.ready ?? false)
+
+            function updateReveal() {
+                var shouldReveal = dock.pinned
+                    || (Config.options?.dock.hoverToReveal && (dockMouseArea.containsMouse || graceTimer.running))
+                    || (dockLoader.item?.requestDockShow ?? false)
+                    || workspaceEmpty
+                if (reveal !== shouldReveal)
+                    reveal = shouldReveal
+            }
 
             // TODO: check for multi-monitor situations
             readonly property bool workspaceEmpty: {
@@ -84,6 +95,8 @@ Scope {
                 if (wsId === -1) return true
                 return HyprlandData.hyprlandClientsForWorkspace(wsId).length === 0
             }
+
+            onWorkspaceEmptyChanged: updateReveal()
 
             readonly property var sizing: dock.computeSizes({
                 gapsOut: Appearance.sizes.hyprlandGapsOut,
@@ -128,6 +141,7 @@ Scope {
             Timer {
                 id: graceTimer
                 interval: 1000
+                onRunningChanged: dockRoot.updateReveal()
             }
 
             onRevealChanged: {
@@ -135,8 +149,10 @@ Scope {
                 else unloadTimer.stop()
             }
 
+            // Watch dock.pinned changes to update reveal
             Connections {
                 target: dock
+                function onPinnedChanged() { dockRoot.updateReveal() }
                 function onDockEffectivePositionChanged() {
                     dockRoot.positionChanging = true
                     positionChangeTimer.restart()
@@ -172,11 +188,13 @@ Scope {
                     if (containsMouse && !dockRoot.reveal && !dock.pinned) {
                         graceTimer.restart()
                     }
+                    // Update reveal imperatively to avoid binding loop
+                    dockRoot.updateReveal()
                 }
 
                 property real hiddenOffset: dockRoot.dockThickness - (Config.options?.dock.hoverRegionHeight ?? 10)
                 property real fullyHiddenOffset: dockRoot.dockThickness + 1
-                property real currentOffset: dockRoot.reveal ? 0 : (Config.options?.dock.hoverToReveal ? hiddenOffset : fullyHiddenOffset)
+                property real currentOffset: dockRoot.readyToReveal ? 0 : (Config.options?.dock.hoverToReveal ? hiddenOffset : fullyHiddenOffset)
 
                 width: dock.isVertical ? dockRoot.dockThickness : dockRoot.sizing.dockWidth
                 height: dock.isVertical ? dockRoot.sizing.dockHeight : dockRoot.dockThickness
@@ -230,13 +248,18 @@ Scope {
                             readonly property real dockPadding: content.dockPadding
                             readonly property string dragState: content.dragState
                             readonly property bool requestDockShow: content.requestDockShow
-                            
+                            readonly property bool ready: content.ready
+
                             function endDrag() { content.endDrag() }
                             function endFileDrag() { content.endFileDrag() }
                             function mimeIconFromPath(p) { return content.mimeIconFromPath(p) }
 
-                            opacity: (dockLoader.activeAsync && !dockRoot.positionChanging) ? 1.0 : 0.0
-                            Behavior on opacity { NumberAnimation { duration: 150 } }
+                            // When requestDockShow changes inside the loaded content, update reveal
+                            onRequestDockShowChanged: dockRoot.updateReveal()
+
+                            // Only show once DockContent itself is ready 
+                            readonly property bool contentReady: content.ready && !dockRoot.positionChanging
+                            opacity: contentReady ? 1.0 : 0.0
 
                             StyledRectangularShadow { 
                                 target: visualBackground

--- a/dots/.config/quickshell/ii/modules/ii/dock/DockContent.qml
+++ b/dots/.config/quickshell/ii/modules/ii/dock/DockContent.qml
@@ -512,9 +512,11 @@ Item {
         fileResolvedIcon: draggedFileDelegate?.resolvedXdgIcon ?? ""
 
         scale: {
-            const intent = root.dragActive ? root.dragIntent : root.fileDragIntent;
-            const pinned = root.dragActive ? TaskbarApps.isPinned(root.draggedAppId) : true;
-            return (pinned && intent === "unpin") || (!pinned && intent === "pin") ? 0.7 : 1.0;
+            const intent = root.isFileDrag ? root.fileDragIntent : root.dragIntent;
+            const isPinned = root.isFileDrag || TaskbarApps.isPinned(root.draggedAppId);
+            if (intent === "unpin" && isPinned) return 0.7;
+            if (intent === "pin" && !isPinned) return 0.7;
+            return 1.0;
         }
         Behavior on scale {
             animation: Appearance.animation.elementResize.numberAnimation.createObject(this)

--- a/dots/.config/quickshell/ii/modules/ii/dock/DockContent.qml
+++ b/dots/.config/quickshell/ii/modules/ii/dock/DockContent.qml
@@ -405,11 +405,17 @@ Item {
                 }
 
                 Item {
+                    id: fileListWrapper
                     Layout.alignment: Qt.AlignCenter
                     Layout.preferredWidth: root.isVertical ? root.buttonSlotSize : (root.processedFiles.length > 0 ? fileListView.contentWidth : 0)
                     Layout.preferredHeight: root.isVertical ? (root.processedFiles.length > 0 ? fileListView.contentHeight : 0) : root.buttonSlotSize
-                    visible: root.processedFiles.length > 0
+                    opacity: root.processedFiles.length > 0 ? 1.0 : 0.0
+                    visible: root.processedFiles.length > 0 || opacity > 0.01
                     clip: true
+
+                    Behavior on opacity {
+                        animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+                    }
                     Behavior on Layout.preferredWidth {
                         enabled: !root.suppressSizeAnimation && !root.isVertical
                         animation: Appearance.animation.elementMove.numberAnimation.createObject(this)

--- a/dots/.config/quickshell/ii/modules/ii/dock/DockContent.qml
+++ b/dots/.config/quickshell/ii/modules/ii/dock/DockContent.qml
@@ -30,6 +30,7 @@ Item {
     readonly property real visualWidth: isVertical ? Appearance.sizes.dockButtonSize + dotMargin * 2 : mainLayout.implicitWidth
     readonly property real visualHeight: isVertical ? mainLayout.implicitHeight : Appearance.sizes.dockButtonSize + dotMargin * 2
 
+    readonly property bool ready: (isVertical ? visualHeight > 0 : visualWidth > 0) && !suppressSizeAnimation
     readonly property bool requestDockShow: previewPopupLoader.item?.visible || anyContextMenuOpen
 
     readonly property real maxWindowPreviewHeight: 200
@@ -273,9 +274,18 @@ Item {
         }
     }
 
+    property bool suppressSizeAnimation: true
+
+    Timer {
+        id: suppressSizeAnimTimer
+        interval: 150
+        onTriggered: root.suppressSizeAnimation = false
+    }
+
     Component.onCompleted: {
         updateModel();
         updateFileModel();
+        suppressSizeAnimTimer.start();
     }
 
     readonly property real pinButtonCenter: isVertical ? pinButtonWrapper.y + pinButtonWrapper.height / 2 : pinButtonWrapper.x + pinButtonWrapper.width / 2
@@ -401,11 +411,11 @@ Item {
                     visible: root.processedFiles.length > 0
                     clip: true
                     Behavior on Layout.preferredWidth {
-                        enabled: !root.isVertical
+                        enabled: !root.suppressSizeAnimation && !root.isVertical
                         animation: Appearance.animation.elementMove.numberAnimation.createObject(this)
                     }
                     Behavior on Layout.preferredHeight {
-                        enabled: root.isVertical
+                        enabled: !root.suppressSizeAnimation && root.isVertical
                         animation: Appearance.animation.elementMove.numberAnimation.createObject(this)
                     }
 

--- a/dots/.config/quickshell/ii/modules/ii/dock/DockContextMenu.qml
+++ b/dots/.config/quickshell/ii/modules/ii/dock/DockContextMenu.qml
@@ -35,9 +35,8 @@ DockContextMenuBase {
                 Layout.fillWidth: true
 
                 readonly property var shapePool: [
-                    "Flower", "Gem", "SoftBurst", "Clover4Leaf",
-                    "Heart", "Puffy", "Diamond", "Pentagon",
-                    "Cookie6Sided", "SoftBoom", "Bun", "PuffyDiamond"
+                    "Clover4Leaf", "Arrow", "Pill", "SoftBurst",
+                    "Diamond", "ClamShell", "Pentagon"
                 ]
 
                 shapeString: shapePool[index % shapePool.length]

--- a/dots/.config/quickshell/ii/modules/ii/dock/widgets/DockListView.qml
+++ b/dots/.config/quickshell/ii/modules/ii/dock/widgets/DockListView.qml
@@ -26,11 +26,11 @@ StyledListView {
     implicitWidth: root.isVertical ? root.buttonSlotSize : Math.max(1, contentWidth)
     implicitHeight: root.isVertical ? Math.max(1, contentHeight) : root.buttonSlotSize
     Behavior on implicitWidth {
-        enabled: !root.dragActive && !root.isFileDrag
+        enabled: !root.suppressSizeAnimation && !root.dragActive && !root.isFileDrag
         animation: Appearance.animation.elementMove.numberAnimation.createObject(this)
     }
     Behavior on implicitHeight {
-        enabled: !root.dragActive && !root.isFileDrag
+        enabled: !root.suppressSizeAnimation && !root.dragActive && !root.isFileDrag
         animation: Appearance.animation.elementMove.numberAnimation.createObject(this)
     }
     removeDisplaced: Transition {

--- a/dots/.config/quickshell/ii/modules/settings/InterfaceConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/InterfaceConfig.qml
@@ -134,10 +134,10 @@ ContentPage {
         ConfigRow {
             uniform: true
             ConfigSwitch {
-                buttonIcon: "highlight_mouse_cursor"
-                text: Translation.tr("Hover to reveal")
-                checked: Config.options.dock.hoverToReveal
-                onCheckedChanged: { Config.options.dock.hoverToReveal = checked; }
+                buttonIcon: "computer_arrow_up"
+                text: Translation.tr("Reveal on empty workspace")
+                checked: Config.options.dock.revealOnEmptyWorkspace
+                onCheckedChanged: { Config.options.dock.revealOnEmptyWorkspace = checked; }
             }
             ConfigSwitch {
                 buttonIcon: "keep"


### PR DESCRIPTION
## Describe your changes

- fix file drag ghost not resizing

- unload dock when it's hidden: now the mouse area of the dock resizes to max dock length when dock it's hidden and a timer of 1 second starts when dock is revealed to give time to the user to reach the dock. An alternative would be to figure out the size of the dock even when it's hidden and unloaded trying to give the mouse area the real length of the dock. I think the possibility to trigger the dock from all the length of the screen border is not too bad, if you like it it could be leaved this way

- fix file dock list closing without animation

- changed material shape order in dock context menu

## Is it ready? Questions/feedback needed?

Seems to be working fine, maybe some solutions are not optimal, i left some comments in the code.
I also have a question about the hover to reveal option, is it really needed? How to open the dock when it's disabled? Maybe there is something i'm missing.

I'm now considering possible interaction with the hot corners for the sidebars, maybe the mouse area of the dock could be a problem for them: they seem to be working ok, but i never read their code so i'm not sure



