### PR TITLE
feat: Extra wallpaper transition effects

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -259,6 +259,7 @@ Singleton {
                     }
                 }
                 property bool animateWallpaperChanges: true
+                property string transitionType: "radial"
                 property string wallpaperPath: ""
                 property string thumbnailPath: ""
                 property bool hideWhenFullscreen: true

--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -260,6 +260,7 @@ Singleton {
                 }
                 property bool animateWallpaperChanges: true
                 property string transitionType: "radial"
+                property int wipeAngle: 0
                 property string wallpaperPath: ""
                 property string thumbnailPath: ""
                 property bool hideWhenFullscreen: true

--- a/dots/.config/quickshell/ii/modules/common/widgets/TransitionImage.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/TransitionImage.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import Qt5Compat.GraphicalEffects
 import qs.services
 import qs.modules.common
 import qs.modules.common.widgets
@@ -9,11 +10,12 @@ Item {
 
     required property string imageSource
 
-    property int animationDuration: 1000
+    property string transitionType: Config.options.background.transitionType ?? "radial"
+
+    property int animationDuration: transitionType === "radial" ? 1100 : 1000
     property var fillMode: Image.PreserveAspectCrop
-    property bool animated: true
-    property bool imgAIsBack: true
-    
+    property bool animated: Config.options.background.animateWallpaperChanges
+
     property var sourceSize: Qt.size(0, 0)
     property bool cache: false
     property bool antialiasing: true
@@ -21,55 +23,124 @@ Item {
     property bool smooth: true
     property bool mipmap: true
 
+    property bool transitionActive: false
+    property bool ready: false
+
+    property bool imgAIsBack: true
+    property Item backImg: imgAIsBack ? imgA : imgB
+    property Item frontImg: imgAIsBack ? imgB : imgA
+
+    property int status: backImg.status
+
+    Component.onCompleted: ready = true
+
     onImageSourceChanged: fadeTo(imageSource)
-    Component.onCompleted: imgA.source = imageSource
 
     function fadeTo(newSrc) {
-        var back  = imgAIsBack ? imgA : imgB
-        var front = imgAIsBack ? imgB : imgA
+        if (!newSrc || newSrc === backImg.source) return
 
-        if (newSrc === back.source) return
-
-        front.source  = newSrc
-        front.z       = 1
-        back.z        = 0
-
-        if (root.animated) {
-            front.opacity = 0
-            fadeAnim.target = front
-            fadeAnim.restart()
-        } else {
-            front.opacity = 1
+        if (root.animated && ready && root.width > 0 && root.height > 0) {
+            cleanupTransition()
+            
+            // Flip AT THE START so frontImg is ALWAYS the new image with z=1
             root.imgAIsBack = !root.imgAIsBack
+            
+            root.transitionActive = true
+            frontImg.source = newSrc 
+            
+            let wait = effectLoader.item ? effectLoader.item.waitForReady !== false : true
+            
+            if (!wait || frontImg.status === Image.Ready) {
+                startTransition()
+            }
+        } else {
+            cleanupTransition()
+            root.imgAIsBack       = !root.imgAIsBack 
+            frontImg.source       = newSrc
+            root.transitionActive = false
         }
     }
 
-    NumberAnimation {
-        id: fadeAnim
-        property: "opacity"
-        from: 0; to: 1
-        duration: root.animationDuration
-        easing.type: Easing.InOutQuad
+    function startTransition() {
+        if (effectLoader.item && typeof effectLoader.item.start === "function") {
+            effectLoader.item.start()
+        } else {
+            cleanupTransition()
+        }
+    }
 
-        onFinished: {
-            root.imgAIsBack = !root.imgAIsBack
+    function cleanupTransition() {
+        root.transitionActive = false
+        if (effectLoader.item && typeof effectLoader.item.cleanup === "function") {
+            effectLoader.item.cleanup()
         }
     }
 
     Image {
         id: imgA
         anchors.fill: parent
-        fillMode: root.fillMode
-        sourceSize: root.sourceSize
-        cache: root.cache; antialiasing: root.antialiasing; asynchronous: root.asynchronous; smooth: root.smooth; mipmap: root.mipmap
+        // Visible if backImg OR (if frontImg and no hideFront requested during transition)
+        visible: root.imgAIsBack || (!root.transitionActive || !effectLoader.item || effectLoader.item.hideFront === false)
+        layer.enabled: !visible && root.transitionActive 
+        z:       root.imgAIsBack ? 0 : 1
+
+        fillMode:     root.fillMode
+        sourceSize:   root.sourceSize
+        cache: root.cache; antialiasing: root.antialiasing
+        asynchronous: root.asynchronous; smooth: root.smooth; mipmap: root.mipmap
+
+        onStatusChanged: {
+            let wait = effectLoader.item ? effectLoader.item.waitForReady !== false : true
+            if (wait) {
+                if (status === Image.Ready && root.transitionActive && !root.imgAIsBack) {
+                    root.startTransition()
+                } else if (status === Image.Error && root.transitionActive && !root.imgAIsBack) {
+                    root.cleanupTransition()
+                }
+            }
+        }
     }
 
     Image {
         id: imgB
         anchors.fill: parent
-        opacity: 0
-        fillMode: root.fillMode
-        sourceSize: root.sourceSize
-        cache: root.cache; antialiasing: root.antialiasing; asynchronous: root.asynchronous; smooth: root.smooth; mipmap: root.mipmap
+        visible: !root.imgAIsBack || (!root.transitionActive || !effectLoader.item || effectLoader.item.hideFront === false)
+        layer.enabled: !visible && root.transitionActive
+        z:       !root.imgAIsBack ? 0 : 1
+
+        fillMode:     root.fillMode
+        sourceSize:   root.sourceSize
+        cache: root.cache; antialiasing: root.antialiasing
+        asynchronous: root.asynchronous; smooth: root.smooth; mipmap: root.mipmap
+        
+        onStatusChanged: {
+            let wait = effectLoader.item ? effectLoader.item.waitForReady !== false : true
+            if (wait) {
+                if (status === Image.Ready && root.transitionActive && root.imgAIsBack) {
+                    root.startTransition()
+                } else if (status === Image.Error && root.transitionActive && root.imgAIsBack) {
+                    root.cleanupTransition()
+                }
+            }
+        }
+    }
+
+    Loader {
+        id: effectLoader
+        anchors.fill: parent
+        source: "transitions/" + (root.transitionType.charAt(0).toUpperCase() + root.transitionType.slice(1)) + ".qml"
+
+        onLoaded: {
+            item.frontImg = Qt.binding(function() { return root.frontImg })
+            item.backImg = Qt.binding(function() { return root.backImg })
+            item.duration = Qt.binding(function() { return root.animationDuration })
+        }
+        
+        Connections {
+            target: effectLoader.item
+            function onFinished() {
+                root.cleanupTransition()
+            }
+        }
     }
 }

--- a/dots/.config/quickshell/ii/modules/common/widgets/TransitionImage.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/TransitionImage.qml
@@ -30,7 +30,7 @@ Item {
     property Item backImg: imgAIsBack ? imgA : imgB
     property Item frontImg: imgAIsBack ? imgB : imgA
 
-    property int status: backImg.status
+    property int status: (imgA.status === Image.Ready || imgB.status === Image.Ready) ? Image.Ready : frontImg.status
 
     Component.onCompleted: ready = true
 
@@ -39,7 +39,7 @@ Item {
     function fadeTo(newSrc) {
         if (!newSrc || newSrc === backImg.source) return
 
-        if (root.animated && ready && root.width > 0 && root.height > 0) {
+        if (root.animated && ready && root.width > 0 && root.height > 0 && String(backImg.source) !== "") {
             cleanupTransition()
             
             // Flip AT THE START so frontImg is ALWAYS the new image with z=1

--- a/dots/.config/quickshell/ii/modules/common/widgets/TransitionImage.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/TransitionImage.qml
@@ -36,10 +36,14 @@ Item {
 
     onImageSourceChanged: fadeTo(imageSource)
 
-    function fadeTo(newSrc) {
-        if (!newSrc || newSrc === backImg.source) return
+    property string currentWallpaper: ""
 
-        if (root.animated && ready && root.width > 0 && root.height > 0 && String(backImg.source) !== "") {
+    function fadeTo(newSrc) {
+        if (!newSrc || newSrc === currentWallpaper) return
+
+        let hasWallpaper = (currentWallpaper !== "")
+
+        if (root.animated && ready && root.width > 0 && root.height > 0 && hasWallpaper) {
             cleanupTransition()
             
             // Flip AT THE START so frontImg is ALWAYS the new image with z=1
@@ -47,6 +51,7 @@ Item {
             
             root.transitionActive = true
             frontImg.source = newSrc 
+            currentWallpaper = newSrc
             
             let wait = effectLoader.item ? effectLoader.item.waitForReady !== false : true
             
@@ -57,6 +62,7 @@ Item {
             cleanupTransition()
             root.imgAIsBack       = !root.imgAIsBack 
             frontImg.source       = newSrc
+            currentWallpaper      = newSrc
             root.transitionActive = false
         }
     }

--- a/dots/.config/quickshell/ii/modules/common/widgets/transitions/Crossfade.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/transitions/Crossfade.qml
@@ -1,0 +1,32 @@
+import QtQuick
+
+Item {
+    id: effect
+    property Item frontImg
+    property Item backImg
+    property int duration
+
+    property bool hideFront: false
+    property bool waitForReady: false
+    signal finished()
+
+    function start() {
+        frontImg.opacity = 0
+        fadeAnim.restart()
+    }
+
+    function cleanup() {
+        fadeAnim.stop()
+    }
+
+    NumberAnimation {
+        id: fadeAnim
+        target: effect.frontImg
+        property: "opacity"
+        from: 0
+        to: 1
+        duration: effect.duration
+        easing.type: Easing.InOutQuad
+        onFinished: effect.finished()
+    }
+}

--- a/dots/.config/quickshell/ii/modules/common/widgets/transitions/Diamond.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/transitions/Diamond.qml
@@ -46,7 +46,7 @@ Item {
         target: circleMask
         property: "scale"
         duration: effect.duration
-        easing.type: Easing.Bezier
+        easing.type: Easing.BezierSpline
         easing.bezierCurve: [0.227, 0.877, 0.959, 0.310, 1.0, 1.0]
         onFinished: effect.finished()
     }

--- a/dots/.config/quickshell/ii/modules/common/widgets/transitions/Diamond.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/transitions/Diamond.qml
@@ -1,0 +1,90 @@
+import QtQuick
+import Qt5Compat.GraphicalEffects
+
+Item {
+    id: effect
+    property Item frontImg
+    property Item backImg
+    property int duration
+
+    property bool hideFront: true
+    signal finished()
+
+    function start() {
+        maskContainer.layer.enabled = true
+        
+        let marginX = effect.width * 0.25
+        let marginY = effect.height * 0.25
+        let cx = marginX + Math.random() * (effect.width - marginX * 2)
+        let cy = marginY + Math.random() * (effect.height - marginY * 2)
+        circleMask.centerX = cx
+        circleMask.centerY = cy
+
+        let d1 = Math.sqrt(cx * cx + cy * cy)
+        let d2 = Math.sqrt((effect.width - cx) * (effect.width - cx) + cy * cy)
+        let d3 = Math.sqrt(cx * cx + (effect.height - cy) * (effect.height - cy))
+        let d4 = Math.sqrt((effect.width - cx) * (effect.width - cx) + (effect.height - cy) * (effect.height - cy))
+        let targetDiameter = Math.ceil(Math.max(d1, d2, d3, d4)) * 2
+        let targetScale = targetDiameter / circleMask.width
+
+        circleMask.scale = 0
+        wipeMask.visible = true
+
+        revealAnim.from = 0
+        revealAnim.to = targetScale
+        revealAnim.restart()
+    }
+
+    function cleanup() {
+        wipeMask.visible = false
+        circleMask.scale = 0
+        maskContainer.layer.enabled = false
+    }
+
+    NumberAnimation {
+        id: revealAnim
+        target: circleMask
+        property: "scale"
+        duration: effect.duration
+        easing.type: Easing.OutCubic
+        onFinished: effect.finished()
+    }
+
+    Item {
+        id: maskContainer
+        width: effect.width
+        height: effect.height
+        visible: false
+        layer.enabled: false
+
+        Item {
+            id: pivot
+            x: circleMask.centerX
+            y: circleMask.centerY
+            width: 1
+            height: 1
+
+            Rectangle {
+                id: circleMask
+                anchors.centerIn: parent
+                width: 200
+                height: 200
+                color: "black"
+                scale: 0
+                rotation: 45
+                transformOrigin: Item.Center
+
+                property real centerX: effect.width / 2
+                property real centerY: effect.height / 2
+            }
+        }
+    }
+
+    OpacityMask {
+        id: wipeMask
+        anchors.fill: parent
+        visible: false
+        source: effect.frontImg
+        maskSource: maskContainer
+    }
+}

--- a/dots/.config/quickshell/ii/modules/common/widgets/transitions/Diamond.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/transitions/Diamond.qml
@@ -46,7 +46,8 @@ Item {
         target: circleMask
         property: "scale"
         duration: effect.duration
-        easing.type: Easing.OutCubic
+        easing.type: Easing.Bezier
+        easing.bezierCurve: [0.227, 0.877, 0.959, 0.310, 1.0, 1.0]
         onFinished: effect.finished()
     }
 

--- a/dots/.config/quickshell/ii/modules/common/widgets/transitions/Radial.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/transitions/Radial.qml
@@ -46,7 +46,7 @@ Item {
         target: circleMask
         property: "scale"
         duration: effect.duration
-        easing.type: Easing.Bezier
+        easing.type: Easing.BezierSpline
         easing.bezierCurve: [0.227, 0.877, 0.959, 0.310, 1.0, 1.0]
         onFinished: effect.finished()
     }

--- a/dots/.config/quickshell/ii/modules/common/widgets/transitions/Radial.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/transitions/Radial.qml
@@ -1,0 +1,85 @@
+import QtQuick
+import Qt5Compat.GraphicalEffects
+
+Item {
+    id: effect
+    property Item frontImg
+    property Item backImg
+    property int duration
+
+    property bool hideFront: true
+    signal finished()
+
+    function start() {
+        maskContainer.layer.enabled = true
+        
+        let marginX = effect.width * 0.25
+        let marginY = effect.height * 0.25
+        let cx = marginX + Math.random() * (effect.width - marginX * 2)
+        let cy = marginY + Math.random() * (effect.height - marginY * 2)
+        circleMask.centerX = cx
+        circleMask.centerY = cy
+
+        let d1 = Math.sqrt(cx * cx + cy * cy)
+        let d2 = Math.sqrt((effect.width - cx) * (effect.width - cx) + cy * cy)
+        let d3 = Math.sqrt(cx * cx + (effect.height - cy) * (effect.height - cy))
+        let d4 = Math.sqrt((effect.width - cx) * (effect.width - cx) + (effect.height - cy) * (effect.height - cy))
+        let targetDiameter = Math.ceil(Math.max(d1, d2, d3, d4)) * 2
+        let targetScale = targetDiameter / circleMask.width
+
+        circleMask.scale = 0
+        wipeMask.visible = true
+
+        revealAnim.from = 0
+        revealAnim.to = targetScale
+        revealAnim.restart()
+    }
+
+    function cleanup() {
+        wipeMask.visible = false
+        circleMask.scale = 0
+        maskContainer.layer.enabled = false
+    }
+
+    NumberAnimation {
+        id: revealAnim
+        target: circleMask
+        property: "scale"
+        duration: effect.duration
+        easing.type: Easing.BezierSpline
+        easing.bezierCurve: [0.12, 1.0, 0.4, 1.0]
+        onFinished: effect.finished()
+    }
+
+    Item {
+        id: maskContainer
+        width: effect.width
+        height: effect.height
+        visible: false
+        layer.enabled: false
+
+        Rectangle {
+            id: circleMask
+            width: 200
+            height: 200
+            radius: 100
+            color: "black"
+            scale: 0
+            transformOrigin: Item.Center
+
+            property real centerX: effect.width / 2
+            property real centerY: effect.height / 2
+
+            x: centerX - width / 2
+            y: centerY - height / 2
+        }
+    }
+
+    OpacityMask {
+        id: wipeMask
+        anchors.fill: parent
+        visible: false
+        source: effect.frontImg
+        maskSource: maskContainer
+    }
+}

--- a/dots/.config/quickshell/ii/modules/common/widgets/transitions/Radial.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/transitions/Radial.qml
@@ -46,8 +46,8 @@ Item {
         target: circleMask
         property: "scale"
         duration: effect.duration
-        easing.type: Easing.BezierSpline
-        easing.bezierCurve: [0.12, 1.0, 0.4, 1.0]
+        easing.type: Easing.Bezier
+        easing.bezierCurve: [0.227, 0.877, 0.959, 0.310, 1.0, 1.0]
         onFinished: effect.finished()
     }
 

--- a/dots/.config/quickshell/ii/modules/common/widgets/transitions/Slash.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/transitions/Slash.qml
@@ -1,0 +1,88 @@
+import QtQuick
+import Qt5Compat.GraphicalEffects
+
+Item {
+    id: effect
+    property Item frontImg
+    property Item backImg
+    property int duration
+
+    property bool hideFront: true
+    signal finished()
+
+    function start() {
+        maskContainer.layer.enabled = true
+        
+        let marginX = effect.width * 0.25
+        let marginY = effect.height * 0.25
+        let cx = marginX + Math.random() * (effect.width - marginX * 2)
+        let cy = marginY + Math.random() * (effect.height - marginY * 2)
+        circleMask.centerX = cx
+        circleMask.centerY = cy
+
+        let d1 = Math.sqrt(cx * cx + cy * cy)
+        let d2 = Math.sqrt((effect.width - cx) * (effect.width - cx) + cy * cy)
+        let d3 = Math.sqrt(cx * cx + (effect.height - cy) * (effect.height - cy))
+        let d4 = Math.sqrt((effect.width - cx) * (effect.width - cx) + (effect.height - cy) * (effect.height - cy))
+        let targetDiameter = Math.ceil(Math.max(d1, d2, d3, d4)) * 2
+
+        circleMask.width = 0
+        wipeMask.visible = true
+
+        revealAnim.from = 0
+        revealAnim.to = targetDiameter
+        revealAnim.restart()
+    }
+
+    function cleanup() {
+        wipeMask.visible = false
+        circleMask.width = 0
+        maskContainer.layer.enabled = false
+    }
+
+    NumberAnimation {
+        id: revealAnim
+        target: circleMask
+        property: "width"
+        duration: effect.duration
+        easing.type: Easing.OutCubic
+        onFinished: effect.finished()
+    }
+
+    Item {
+        id: maskContainer
+        width: effect.width
+        height: effect.height
+        visible: false
+        layer.enabled: false
+
+        Item {
+            id: pivot
+            x: circleMask.centerX
+            y: circleMask.centerY
+            width: 1
+            height: 1
+
+            Rectangle {
+                id: circleMask
+                anchors.centerIn: parent
+                width: 0
+                height: Math.ceil(Math.sqrt(effect.width * effect.width + effect.height * effect.height)) * 2
+                color: "black"
+                rotation: 45
+                transformOrigin: Item.Center
+
+                property real centerX: effect.width / 2
+                property real centerY: effect.height / 2
+            }
+        }
+    }
+
+    OpacityMask {
+        id: wipeMask
+        anchors.fill: parent
+        visible: false
+        source: effect.frontImg
+        maskSource: maskContainer
+    }
+}

--- a/dots/.config/quickshell/ii/modules/common/widgets/transitions/Slash.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/transitions/Slash.qml
@@ -48,7 +48,7 @@ Item {
         target: circleMask
         property: "scale" // Animate scale, not width!
         duration: effect.duration
-        easing.type: Easing.Bezier
+        easing.type: Easing.BezierSpline
         easing.bezierCurve: [0.227, 0.877, 0.959, 0.310, 1.0, 1.0]
         onFinished: effect.finished()
     }

--- a/dots/.config/quickshell/ii/modules/common/widgets/transitions/Slash.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/transitions/Slash.qml
@@ -48,7 +48,8 @@ Item {
         target: circleMask
         property: "scale" // Animate scale, not width!
         duration: effect.duration
-        easing.type: Easing.OutCubic
+        easing.type: Easing.Bezier
+        easing.bezierCurve: [0.227, 0.877, 0.959, 0.310, 1.0, 1.0]
         onFinished: effect.finished()
     }
 

--- a/dots/.config/quickshell/ii/modules/common/widgets/transitions/Slash.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/transitions/Slash.qml
@@ -26,24 +26,27 @@ Item {
         let d4 = Math.sqrt((effect.width - cx) * (effect.width - cx) + (effect.height - cy) * (effect.height - cy))
         let targetDiameter = Math.ceil(Math.max(d1, d2, d3, d4)) * 2
 
-        circleMask.width = 0
+        // Divide target by our fixed base width (100)
+        let targetScale = targetDiameter / 100
+
+        circleMask.scale = 0 // Start invisible
         wipeMask.visible = true
 
         revealAnim.from = 0
-        revealAnim.to = targetDiameter
+        revealAnim.to = targetScale
         revealAnim.restart()
     }
 
     function cleanup() {
         wipeMask.visible = false
-        circleMask.width = 0
+        circleMask.scale = 0
         maskContainer.layer.enabled = false
     }
 
     NumberAnimation {
         id: revealAnim
         target: circleMask
-        property: "width"
+        property: "scale" // Animate scale, not width!
         duration: effect.duration
         easing.type: Easing.OutCubic
         onFinished: effect.finished()
@@ -66,10 +69,11 @@ Item {
             Rectangle {
                 id: circleMask
                 anchors.centerIn: parent
-                width: 0
+                width: 100 // Fixed base width
                 height: Math.ceil(Math.sqrt(effect.width * effect.width + effect.height * effect.height)) * 2
                 color: "black"
                 rotation: 45
+                scale: 0 // Controlled by animation
                 transformOrigin: Item.Center
 
                 property real centerX: effect.width / 2

--- a/dots/.config/quickshell/ii/modules/common/widgets/transitions/Wipe.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/transitions/Wipe.qml
@@ -32,7 +32,7 @@ Item {
         target: wipeRect
         property: "width"
         duration: effect.duration
-        easing.type: Easing.Bezier
+        easing.type: Easing.BezierSpline
         easing.bezierCurve: [0.227, 0.877, 0.959, 0.310, 1.0, 1.0]
         onFinished: effect.finished()
     }

--- a/dots/.config/quickshell/ii/modules/common/widgets/transitions/Wipe.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/transitions/Wipe.qml
@@ -1,0 +1,62 @@
+import QtQuick
+import Qt5Compat.GraphicalEffects
+
+Item {
+    id: effect
+    property Item frontImg
+    property Item backImg
+    property int duration
+
+    property bool hideFront: true
+    signal finished()
+
+    function start() {
+        maskContainer.layer.enabled = true
+        wipeRect.width = 0
+        wipeMask.visible = true
+        
+        revealAnim.from = 0
+        revealAnim.to = effect.width
+        revealAnim.restart()
+    }
+
+    function cleanup() {
+        wipeMask.visible = false
+        wipeRect.width = 0
+        maskContainer.layer.enabled = false
+    }
+
+    NumberAnimation {
+        id: revealAnim
+        target: wipeRect
+        property: "width"
+        duration: effect.duration
+        easing.type: Easing.InOutCubic
+        onFinished: effect.finished()
+    }
+
+    Item {
+        id: maskContainer
+        width: effect.width
+        height: effect.height
+        visible: false
+        layer.enabled: false
+
+        Rectangle {
+            id: wipeRect
+            width: 0
+            height: effect.height
+            color: "black"
+            x: 0
+            y: 0
+        }
+    }
+
+    OpacityMask {
+        id: wipeMask
+        anchors.fill: parent
+        visible: false
+        source: effect.frontImg
+        maskSource: maskContainer
+    }
+}

--- a/dots/.config/quickshell/ii/modules/common/widgets/transitions/Wipe.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/transitions/Wipe.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import Qt5Compat.GraphicalEffects
+import qs.modules.common
 
 Item {
     id: effect
@@ -16,7 +17,7 @@ Item {
         wipeMask.visible = true
         
         revealAnim.from = 0
-        revealAnim.to = effect.width
+        revealAnim.to = pivot.diagonal
         revealAnim.restart()
     }
 
@@ -43,13 +44,22 @@ Item {
         visible: false
         layer.enabled: false
 
-        Rectangle {
-            id: wipeRect
-            width: 0
-            height: effect.height
-            color: "black"
-            x: 0
-            y: 0
+        Item {
+            id: pivot
+            x: effect.width / 2
+            y: effect.height / 2
+            rotation: Config.options.background.wipeAngle ?? 0
+            
+            property real diagonal: Math.ceil(Math.sqrt(effect.width * effect.width + effect.height * effect.height))
+
+            Rectangle {
+                id: wipeRect
+                color: "black"
+                height: pivot.diagonal
+                y: -pivot.diagonal / 2
+                x: -pivot.diagonal / 2
+                width: 0
+            }
         }
     }
 

--- a/dots/.config/quickshell/ii/modules/common/widgets/transitions/Wipe.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/transitions/Wipe.qml
@@ -31,7 +31,8 @@ Item {
         target: wipeRect
         property: "width"
         duration: effect.duration
-        easing.type: Easing.InOutCubic
+        easing.type: Easing.Bezier
+        easing.bezierCurve: [0.227, 0.877, 0.959, 0.310, 1.0, 1.0]
         onFinished: effect.finished()
     }
 

--- a/dots/.config/quickshell/ii/modules/settings/BackgroundConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/BackgroundConfig.qml
@@ -92,6 +92,18 @@ ContentPage {
                         icon: "swap_horiz",
                         value: "wipe",
                         tooltip: Translation.tr("Wipes the screen horizontally to reveal the new wallpaper")
+                    },
+                    {
+                        displayName: Translation.tr("Diamond Wipe"),
+                        icon: "diamond",
+                        value: "diamond",
+                        tooltip: Translation.tr("Expands a 4-sided diamond outward from the center to reveal the new wallpaper")
+                    },
+                    {
+                        displayName: Translation.tr("Slash Wipe"),
+                        icon: "timeline",
+                        value: "slash",
+                        tooltip: Translation.tr("Expands a 45-degree slash line outward to reveal the new wallpaper")
                     }
                 ]
             }

--- a/dots/.config/quickshell/ii/modules/settings/BackgroundConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/BackgroundConfig.qml
@@ -69,50 +69,50 @@ ContentPage {
         ContentSubsection {
             visible: Config.options.background.animateWallpaperChanges
             title: Translation.tr("Wallpaper transition style")
-            ConfigSelectionArray {
-                currentValue: Config.options.background.transitionType
-                onSelected: newValue => {
-                    Config.options.background.transitionType = newValue;
-                }
-                options: [
+
+            StyledComboBox {
+                textRole: "displayName"
+                model: [
                     {
                         displayName: Translation.tr("Radial Wipe"),
                         icon: "circle",
                         value: "radial",
-                        tooltip: Translation.tr("Expands a circle outward from the center to reveal the new wallpaper")
                     },
                     {
                         displayName: Translation.tr("Crossfade"),
                         icon: "blur_on",
                         value: "crossfade",
-                        tooltip: Translation.tr("Smoothly blends the old wallpaper into the new one")
                     },
                     {
                         displayName: Translation.tr("Linear Wipe"),
-                        icon: "swap_horiz",
+                        icon: "blur_linear",
                         value: "wipe",
-                        tooltip: Translation.tr("Wipes the screen horizontally to reveal the new wallpaper")
                     },
                     {
                         displayName: Translation.tr("Diamond Wipe"),
-                        icon: "diamond",
+                        icon: "nearby",
                         value: "diamond",
-                        tooltip: Translation.tr("Expands a 4-sided diamond outward from the center to reveal the new wallpaper")
                     },
                     {
                         displayName: Translation.tr("Slash Wipe"),
                         icon: "timeline",
                         value: "slash",
-                        tooltip: Translation.tr("Expands a 45-degree slash line outward to reveal the new wallpaper")
                     }
                 ]
+                currentIndex: {
+                    const idx = model.findIndex(item => item.value === Config.options.background.transitionType);
+                    return idx >= 0 ? idx : 0;
+                }
+                onActivated: index => {
+                    Config.options.background.transitionType = model[index].value;
+                }
             }
 
             ConfigSpinBox {
                 visible: Config.options.background.transitionType === "wipe"
                 Layout.fillWidth: true
                 icon: "rotate_right"
-                text: Translation.tr("Wipe Angle (0° starts from left side)")
+                text: Translation.tr("Wipe Angle")
                 value: Config.options.background.wipeAngle
                 from: 0
                 to: 359

--- a/dots/.config/quickshell/ii/modules/settings/BackgroundConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/BackgroundConfig.qml
@@ -65,6 +65,37 @@ ContentPage {
                 Config.options.background.animateWallpaperChanges = checked;
             }
         }
+        
+        ContentSubsection {
+            visible: Config.options.background.animateWallpaperChanges
+            title: Translation.tr("Wallpaper transition style")
+            ConfigSelectionArray {
+                currentValue: Config.options.background.transitionType
+                onSelected: newValue => {
+                    Config.options.background.transitionType = newValue;
+                }
+                options: [
+                    {
+                        displayName: Translation.tr("Radial Wipe"),
+                        icon: "circle",
+                        value: "radial",
+                        tooltip: Translation.tr("Expands a circle outward from the center to reveal the new wallpaper")
+                    },
+                    {
+                        displayName: Translation.tr("Crossfade"),
+                        icon: "blur_on",
+                        value: "crossfade",
+                        tooltip: Translation.tr("Smoothly blends the old wallpaper into the new one")
+                    },
+                    {
+                        displayName: Translation.tr("Linear Wipe"),
+                        icon: "swap_horiz",
+                        value: "wipe",
+                        tooltip: Translation.tr("Wipes the screen horizontally to reveal the new wallpaper")
+                    }
+                ]
+            }
+        }
     }
 
     ContentSection {

--- a/dots/.config/quickshell/ii/modules/settings/BackgroundConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/BackgroundConfig.qml
@@ -95,6 +95,20 @@ ContentPage {
                     }
                 ]
             }
+
+            ConfigSpinBox {
+                visible: Config.options.background.transitionType === "wipe"
+                Layout.fillWidth: true
+                icon: "rotate_right"
+                text: Translation.tr("Wipe Angle (0° starts from left side)")
+                value: Config.options.background.wipeAngle
+                from: 0
+                to: 359
+                stepSize: 1
+                onValueChanged: {
+                    Config.options.background.wipeAngle = value;
+                }
+            }
         }
     }
 

--- a/dots/.config/quickshell/ii/modules/settings/QuickConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/QuickConfig.qml
@@ -238,9 +238,6 @@ ContentPage {
                 }
             }
         }
-        
-
-        
         ConfigSwitch {
             buttonIcon: "ev_shadow"
             text: Translation.tr("Transparency")

--- a/dots/.config/quickshell/ii/modules/settings/QuickConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/QuickConfig.qml
@@ -238,6 +238,35 @@ ContentPage {
                 }
             }
         }
+        
+        ContentSubsection {
+            visible: Config.options.background.animateWallpaperChanges
+            title: Translation.tr("Wallpaper transition style")
+            ConfigSelectionArray {
+                currentValue: Config.options.background.transitionType
+                onSelected: newValue => {
+                    Config.options.background.transitionType = newValue;
+                }
+                options: [
+                    {
+                        displayName: Translation.tr("Radial Wipe"),
+                        icon: "circle",
+                        value: "radial"
+                    },
+                    {
+                        displayName: Translation.tr("Crossfade"),
+                        icon: "blur_on",
+                        value: "crossfade"
+                    },
+                    {
+                        displayName: Translation.tr("Linear Wipe"),
+                        icon: "swap_horiz",
+                        value: "wipe"
+                    }
+                ]
+            }
+        }
+        
         ConfigSwitch {
             buttonIcon: "ev_shadow"
             text: Translation.tr("Transparency")

--- a/dots/.config/quickshell/ii/modules/settings/QuickConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/QuickConfig.qml
@@ -239,33 +239,7 @@ ContentPage {
             }
         }
         
-        ContentSubsection {
-            visible: Config.options.background.animateWallpaperChanges
-            title: Translation.tr("Wallpaper transition style")
-            ConfigSelectionArray {
-                currentValue: Config.options.background.transitionType
-                onSelected: newValue => {
-                    Config.options.background.transitionType = newValue;
-                }
-                options: [
-                    {
-                        displayName: Translation.tr("Radial Wipe"),
-                        icon: "circle",
-                        value: "radial"
-                    },
-                    {
-                        displayName: Translation.tr("Crossfade"),
-                        icon: "blur_on",
-                        value: "crossfade"
-                    },
-                    {
-                        displayName: Translation.tr("Linear Wipe"),
-                        icon: "swap_horiz",
-                        value: "wipe"
-                    }
-                ]
-            }
-        }
+
         
         ConfigSwitch {
             buttonIcon: "ev_shadow"


### PR DESCRIPTION
## Describe your changes


https://github.com/user-attachments/assets/0dd72986-fe40-4971-b390-46a7554da466



* **Plugin Architecture**: Reimagined `TransitionImage.qml` to load transitions from `modules/common/widgets/transitions/`. Makes it easier to add more as well.
* **Transitions**: Added three built-in plugins: **Crossfade** (instant swap/original behavior), **Radial Wipe**, and **Linear Wipe**.
* **Z-Index Layering Fix**: This prevents any black/blank screen flicker while images load nicely.
* **Settings Toggle**: Added a style selector in **Wallpaper & Colors** settings (in quick tab just above transparency options).

## Is it ready? Questions/feedback needed?

In progress, (might need a tweak on the bazier curve maybe and checking if I missed something). feedback is welcome.


## Disclosure

Got help from AI for the following:
- bazier curve (i'm not good with this).
- refactoring code to look beautiful.
- finding animations to add.
- finding errors.