### PR TITLE
Bug: text input does not work in the cheatsheet tabs (search/add fields)

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/cheatsheet/Cheatsheet.qml
+++ b/dots/.config/quickshell/ii/modules/ii/cheatsheet/Cheatsheet.qml
@@ -62,8 +62,21 @@ Scope { // Scope
             implicitWidth: cheatsheetBackground.width + Appearance.sizes.elevationMargin * 2
             implicitHeight: cheatsheetBackground.height + Appearance.sizes.elevationMargin * 2
             WlrLayershell.namespace: "quickshell:cheatsheet"
-            // Setting this value makes it take its sweet time to open
-            // WlrLayershell.keyboardFocus: WlrKeyboardFocus.OnDemand
+            // Map with None (fast open), then upgrade to OnDemand once the surface is
+            // visible. Setting OnDemand at map time makes the surface take its sweet time
+            // to open on some compositors; deferring it avoids that while still letting
+            // text inputs inside tabs (e.g. extension search/edit fields) receive keyboard.
+            property bool _focusReady: false
+            WlrLayershell.keyboardFocus: _focusReady ? WlrKeyboardFocus.OnDemand : WlrKeyboardFocus.None
+            onVisibleChanged: {
+                if (visible) focusUpgradeTimer.restart();
+                else _focusReady = false;
+            }
+            Timer {
+                id: focusUpgradeTimer
+                interval: 100
+                onTriggered: cheatsheetRoot._focusReady = true
+            }
             color: "transparent"
 
             mask: Region {


### PR DESCRIPTION
## Describe your changes
He cheatsheet window (PanelWindow / wlr-layer-shell) is created without keyboardFocus.

- The line with WlrLayershell.keyboardFocus is commented out (with a note that otherwise the window "takes a long time to open"). When keyboard interactivity is set to None, the compositor does not send any keyboard input to that surface.

- The built-in tabs (Timetable / Keybinds / Elements) do not require text input, so the issue was not noticeable. However, as soon as a tab contains a text field — search, add/edit fields, etc. (for example, tabs provided by extensions through the cheatsheet contribute point) — it becomes impossible to type anything into it: the cursor cannot be focused and no characters are entered.

- This cannot be fixed on the extension side. keyboardFocus is a property of the cheatsheet window itself, and keyboard interactivity in wlr-layer-shell can only be configured by the owner of the surface (the shell). A child Item (the tab page) has no control over it.

If WlrLayershell.keyboardFocus: OnDemand is set immediately when the window is created, some compositors indeed take noticeably longer to show the surface (which is why the original comment was added).

The solution is to open the window with keyboardFocus set to None (for fast startup) and then, once the surface is already visible, switch it to OnDemand using a short timer.

This preserves the fast opening behavior while still allowing keyboard input to work correctly.