### PR TITLE
Clock animation optimization

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -219,6 +219,7 @@ Singleton {
                             property bool hourMarks: false
                             property bool dateInClock: true
                             property bool constantlyRotate: false
+                            property bool turnOffRotationOnTiledApps: false
                         }
                         property JsonObject digital: JsonObject {
                             property bool adaptiveAlignment: true

--- a/dots/.config/quickshell/ii/modules/ii/background/Background.qml
+++ b/dots/.config/quickshell/ii/modules/ii/background/Background.qml
@@ -36,6 +36,18 @@ Variants {
 
         // Workspaces
         property HyprlandMonitor monitor: Hyprland.monitorFor(modelData)
+
+        readonly property int activeWorkspaceId: monitor?.activeWorkspace?.id ?? -1
+
+        readonly property bool isCovered: {
+            if (activeWorkspaceId === -1 || !monitor) return false;
+            return HyprlandData.windowList.some(w => w.workspace?.id === activeWorkspaceId && w.monitor === monitor.id && !w.floating);
+        }
+
+        readonly property bool hasFullscreen: {
+            if (activeWorkspaceId === -1 || !monitor) return false;
+            return HyprlandData.windowList.some(w => w.workspace?.id === activeWorkspaceId && w.monitor === monitor.id && (w.fullscreen || w.wayland?.fullscreen));
+        }
         property list<var> relevantWindows: HyprlandData.windowList.filter(win => win.monitor == monitor?.id && win.workspace.id >= 0).sort((a, b) => a.workspace.id - b.workspace.id)
         property int firstWorkspaceId: relevantWindows[0]?.workspace.id || 1
         property int lastWorkspaceId: relevantWindows[relevantWindows.length - 1]?.workspace.id || 10
@@ -462,6 +474,8 @@ Variants {
                         scaledScreenHeight: bgRoot.screen.height / bgRoot.effectiveWallpaperScale
                         wallpaperScale: bgRoot.effectiveWallpaperScale
                         wallpaperSafetyTriggered: bgRoot.wallpaperSafetyTriggered
+                        isCovered: bgRoot.isCovered
+                        hasFullscreen: bgRoot.hasFullscreen
                     }
                 }
 

--- a/dots/.config/quickshell/ii/modules/ii/background/Background.qml
+++ b/dots/.config/quickshell/ii/modules/ii/background/Background.qml
@@ -44,10 +44,6 @@ Variants {
             return HyprlandData.windowList.some(w => w.workspace?.id === activeWorkspaceId && w.monitor === monitor.id && !w.floating);
         }
 
-        readonly property bool hasFullscreen: {
-            if (activeWorkspaceId === -1 || !monitor) return false;
-            return HyprlandData.windowList.some(w => w.workspace?.id === activeWorkspaceId && w.monitor === monitor.id && (w.fullscreen || w.wayland?.fullscreen));
-        }
         property list<var> relevantWindows: HyprlandData.windowList.filter(win => win.monitor == monitor?.id && win.workspace.id >= 0).sort((a, b) => a.workspace.id - b.workspace.id)
         property int firstWorkspaceId: relevantWindows[0]?.workspace.id || 1
         property int lastWorkspaceId: relevantWindows[relevantWindows.length - 1]?.workspace.id || 10
@@ -475,7 +471,6 @@ Variants {
                         wallpaperScale: bgRoot.effectiveWallpaperScale
                         wallpaperSafetyTriggered: bgRoot.wallpaperSafetyTriggered
                         isCovered: bgRoot.isCovered
-                        hasFullscreen: bgRoot.hasFullscreen
                     }
                 }
 

--- a/dots/.config/quickshell/ii/modules/ii/background/widgets/clock/ClockWidget.qml
+++ b/dots/.config/quickshell/ii/modules/ii/background/widgets/clock/ClockWidget.qml
@@ -20,6 +20,8 @@ AbstractBackgroundWidget {
     readonly property bool forceCenter: (GlobalStates.screenLocked && Config.options.lock.centerClock)
     readonly property bool shouldShow: (!Config.options.background.widgets.clock.showOnlyWhenLocked || GlobalStates.screenLocked)
     property bool wallpaperSafetyTriggered: false
+    property bool isCovered: false
+    property bool hasFullscreen: false
     needsColText: clockStyle === "digital"
     x: forceCenter ? ((root.screenWidth - root.width) / 2) : targetX
     y: forceCenter ? ((root.screenHeight - root.height) / 2) : targetY
@@ -49,6 +51,8 @@ AbstractBackgroundWidget {
                 spacing: 10
                 CookieClock {
                     anchors.horizontalCenter: parent.horizontalCenter
+                    isCovered: root.isCovered
+                    hasFullscreen: root.hasFullscreen
                 }
                 FadeLoader {
                     anchors.horizontalCenter: parent.horizontalCenter

--- a/dots/.config/quickshell/ii/modules/ii/background/widgets/clock/ClockWidget.qml
+++ b/dots/.config/quickshell/ii/modules/ii/background/widgets/clock/ClockWidget.qml
@@ -21,7 +21,6 @@ AbstractBackgroundWidget {
     readonly property bool shouldShow: (!Config.options.background.widgets.clock.showOnlyWhenLocked || GlobalStates.screenLocked)
     property bool wallpaperSafetyTriggered: false
     property bool isCovered: false
-    property bool hasFullscreen: false
     needsColText: clockStyle === "digital"
     x: forceCenter ? ((root.screenWidth - root.width) / 2) : targetX
     y: forceCenter ? ((root.screenHeight - root.height) / 2) : targetY
@@ -52,7 +51,6 @@ AbstractBackgroundWidget {
                 CookieClock {
                     anchors.horizontalCenter: parent.horizontalCenter
                     isCovered: root.isCovered
-                    hasFullscreen: root.hasFullscreen
                 }
                 FadeLoader {
                     anchors.horizontalCenter: parent.horizontalCenter

--- a/dots/.config/quickshell/ii/modules/ii/background/widgets/clock/CookieClock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/background/widgets/clock/CookieClock.qml
@@ -17,6 +17,9 @@ Item {
 
     readonly property string clockStyle: Config.options.background.widgets.clock.style
 
+    property bool isCovered: false
+    property bool hasFullscreen: false
+
     property real implicitSize: 230
 
     property color colShadow: Appearance.colors.colShadow
@@ -78,12 +81,17 @@ Item {
 
     property string backgroundStyle: Config.options.background.widgets.clock.cookie.backgroundStyle
     StyledDropShadow {
+        id: shadowItem
         target: backgroundStyle === "sine" ? sineCookieLoader : backgroundStyle === "shape" ? materialShapeCookieLoader : roundedPolygonCookieLoader
+        layer.enabled: true
 
-        RotationAnimation on rotation {
+        RotationAnimation {
+            id: rotateAnim
+            target: shadowItem
+            property: "rotation"
             running: Config.options.background.widgets.clock.cookie.constantlyRotate
+            paused: rotateAnim.running && (Config.options.background.widgets.clock.cookie.turnOffRotationOnTiledApps && root.isCovered)
             duration: 30000
-            easing.type: Easing.Linear
             loops: Animation.Infinite
             from: 360
             to: 0
@@ -193,6 +201,7 @@ Item {
             clockSecond: root.clockSecond
             style: Config.options.background.widgets.clock.cookie.secondHandStyle
             color: root.colSecondHand
+            isCovered: root.isCovered
         }
     }
 

--- a/dots/.config/quickshell/ii/modules/ii/background/widgets/clock/CookieClock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/background/widgets/clock/CookieClock.qml
@@ -83,7 +83,6 @@ Item {
     StyledDropShadow {
         id: shadowItem
         target: backgroundStyle === "sine" ? sineCookieLoader : backgroundStyle === "shape" ? materialShapeCookieLoader : roundedPolygonCookieLoader
-        layer.enabled: true
 
         RotationAnimation {
             id: rotateAnim

--- a/dots/.config/quickshell/ii/modules/ii/background/widgets/clock/CookieClock.qml
+++ b/dots/.config/quickshell/ii/modules/ii/background/widgets/clock/CookieClock.qml
@@ -18,7 +18,6 @@ Item {
     readonly property string clockStyle: Config.options.background.widgets.clock.style
 
     property bool isCovered: false
-    property bool hasFullscreen: false
 
     property real implicitSize: 230
 
@@ -89,7 +88,7 @@ Item {
             target: shadowItem
             property: "rotation"
             running: Config.options.background.widgets.clock.cookie.constantlyRotate
-            paused: rotateAnim.running && (Config.options.background.widgets.clock.cookie.turnOffRotationOnTiledApps && root.isCovered)
+            paused: Config.options.background.widgets.clock.cookie.turnOffRotationOnTiledApps && root.isCovered
             duration: 30000
             loops: Animation.Infinite
             from: 360

--- a/dots/.config/quickshell/ii/modules/ii/background/widgets/clock/SecondHand.qml
+++ b/dots/.config/quickshell/ii/modules/ii/background/widgets/clock/SecondHand.qml
@@ -15,10 +15,12 @@ Item {
     property string style: "hide"
     property color color: Appearance.colors.colSecondary
     
+    property bool isCovered: false
+
     rotation: (360 / 60 * clockSecond) + 90
 
     Behavior on rotation {
-        enabled: Config.options.background.widgets.clock.cookie.constantlyRotate // Animating every second is expensive...
+        enabled: Config.options.background.widgets.clock.cookie.constantlyRotate && !(Config.options.background.widgets.clock.cookie.turnOffRotationOnTiledApps && root.isCovered)
         animation: RotationAnimation {
             direction: RotationAnimation.Clockwise
             duration: 1000 // 1 second

--- a/dots/.config/quickshell/ii/modules/settings/BackgroundConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/BackgroundConfig.qml
@@ -563,6 +563,22 @@ ContentPage {
                 }
             }
 
+            ConfigSwitch {
+                enabled: Config.options.background.widgets.clock.cookie.constantlyRotate
+                buttonIcon: "pause_circle"
+                text: Translation.tr("No rotation on tiled apps")
+                checked: Config.options.background.widgets.clock.cookie.turnOffRotationOnTiledApps
+                onEnabledChanged: {
+                    checked = Config.options.background.widgets.clock.cookie.turnOffRotationOnTiledApps;
+                }
+                onCheckedChanged: {
+                    Config.options.background.widgets.clock.cookie.turnOffRotationOnTiledApps = checked;
+                }
+                StyledToolTip {
+                    text: Translation.tr("Pauses clock rotation when there is a tiled window on the workspace to save GPU resources.")
+                }
+            }
+
             ConfigRow {
 
                 ConfigSwitch {


### PR DESCRIPTION
## Describe your changes
This PR makes the cookie clock animation pause when not in view thereby saving resources for those who want to see the animation when on empty workspace and don't want it running with opened windows
fixes #78 
<!--- ONE FEATURE PER PULL REQUEST ONLY -->

## Is it ready? Questions/feedback needed?
Yeah.  Works on my machine.


https://github.com/user-attachments/assets/db79e20b-f063-4db0-b084-04225be8db04







