### PR TITLE
fix(overview): match focused monitor by name, not screens-array index

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/overview/Overview.qml
+++ b/dots/.config/quickshell/ii/modules/ii/overview/Overview.qml
@@ -28,7 +28,7 @@ Scope {
             id: realOverviewLoader
             required property var modelData
             property int monitorIndex: overviewVariant.variantModel.indexOf(modelData)
-            property bool monitorIsFocused: (Hyprland.focusedMonitor?.id == monitorIndex)
+            property bool monitorIsFocused: (Hyprland.focusedMonitor?.name === modelData?.name)
             active: monitorIsFocused
 
             component: PanelWindow {


### PR DESCRIPTION
Fixes #84, where I wrote up the full diagnosis. Short version below.

`Overview.qml` compared `Hyprland.focusedMonitor.id` against `monitorIndex`, which is a position in `Quickshell.screens`:

```qml
property int monitorIndex: overviewVariant.variantModel.indexOf(modelData)
property bool monitorIsFocused: (Hyprland.focusedMonitor?.id == monitorIndex)
active: monitorIsFocused
```

Those are two unrelated numbering schemes. They agree on a fresh session, which is why this isn't obvious.

Hyprland assigns incrementing monitor ids and doesn't reuse them, so anything that drops and re-adds a display bumps the id. On a single-monitor setup the index stays 0, so once the id has drifted the comparison is false forever, the `LazyLoader` never activates, and the overview `PanelWindow` is never constructed. Super stops opening search entirely. Restarting quickshell doesn't help because the id doesn't reset; only logging out does, which is what makes it look like a compositor problem.

Comparing connector names fixes it, since names survive re-adds. `monitorIndex` is left alone, it still feeds `workspaceOffset` / `workspaceMap`.

The [ii-eve](https://github.com/djOB2EOTWQW1/ii-eve) fork independently landed the same line, so this shape is already in use downstream:

https://github.com/djOB2EOTWQW1/ii-eve/blob/0273d0937354e666c9aaa44a63c336566ac2bdd7/dots/.config/quickshell/ii/modules/ii/overview/Overview.qml#L30

Upstream end-4 isn't affected, in case anyone checks: it still uses a single always-present `PanelWindow` and compares id against id, so nothing there gates construction on this flag. The mismatch came in with the per-monitor `Variants` + `LazyLoader` rework.

### Testing

Running it on Hyprland 0.56.0 / Quickshell 0.3.0 / Qt 6.11.1, Fedora 44, single DP-3 at 5120x1440. Quickshell hot-reloads the QML, so the fix applies without a relogin. With `focusedMonitor.id` still sitting at 1 and the index at 0:

```
$ hyprctl monitors -j | jq -r '.[] | select(.focused) | "id=\(.id) name=\(.name)"'
id=1 name=DP-3

$ qs -c ii ipc call search toggle
$ hyprctl layers | grep quickshell:overview
Layer 55c9182de7e0: xywh: -35 -70 5225 1580, namespace: quickshell:overview
```

Before the change that same sequence produced no layer at all. Multi-monitor is untested, I only have the one display, though name matching should behave at least as well as index matching there.
