### PR TITLE
feat(osd): add language switcher notification & settings

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -589,6 +589,10 @@ Singleton {
                 property int timeout: 2500
             }
 
+            property JsonObject languageSwitcher: JsonObject {
+                property bool enable: false
+            }
+
             property JsonObject osk: JsonObject {
                 property string layout: "qwerty_full"
                 property bool pinnedOnStartup: false

--- a/dots/.config/quickshell/ii/modules/ii/onScreenDisplay/OnScreenDisplay.qml
+++ b/dots/.config/quickshell/ii/modules/ii/onScreenDisplay/OnScreenDisplay.qml
@@ -33,6 +33,10 @@ Scope {
             id: "gamma",
             sourceUrl: "indicators/GammaIndicator.qml"
         },
+        {
+            id: "language",
+            sourceUrl: "indicators/LanguageIndicator.qml"
+        },
     ]
 
     function triggerOsd() {
@@ -48,6 +52,17 @@ Scope {
         onTriggered: {
             GlobalStates.osdVolumeOpen = false;
             root.protectionMessage = "";
+        }
+    }
+
+    Connections {
+        target: HyprlandXkb
+        function onCurrentLayoutNameChanged() {
+            if (!(Config.options?.languageSwitcher?.enable ?? true))
+                return;
+            root.protectionMessage = "";
+            root.currentIndicator = "language";
+            root.triggerOsd();
         }
     }
 

--- a/dots/.config/quickshell/ii/modules/ii/onScreenDisplay/OsdValueIndicator.qml
+++ b/dots/.config/quickshell/ii/modules/ii/onScreenDisplay/OsdValueIndicator.qml
@@ -10,6 +10,7 @@ Item {
     required property string icon
     required property string name
     property var shape
+    property bool showProgressBar: true
     property bool rotateIcon: false
     property bool scaleIcon: false
     property alias from: valueProgressBar.from
@@ -81,12 +82,14 @@ Item {
                         Layout.fillWidth: false
                         Layout.preferredWidth: 30
                         horizontalAlignment: Text.AlignRight
+                        visible: root.showProgressBar
                         text: Math.round(root.value * 100)
                     }
                 }
                 
                 StyledProgressBar {
                     id: valueProgressBar
+                    visible: root.showProgressBar
                     Layout.fillWidth: true
                     value: root.value
                 }

--- a/dots/.config/quickshell/ii/modules/ii/onScreenDisplay/indicators/LanguageIndicator.qml
+++ b/dots/.config/quickshell/ii/modules/ii/onScreenDisplay/indicators/LanguageIndicator.qml
@@ -1,0 +1,14 @@
+import qs.services
+import QtQuick
+import qs.modules.ii.onScreenDisplay
+import qs.modules.common.widgets
+
+OsdValueIndicator {
+    id: root
+
+    value: 0
+    showProgressBar: false
+    icon: "language"
+    name: HyprlandXkb.currentLayoutName || "English (US)"
+    shape: MaterialShape.Shape.Cookie7Sided
+}

--- a/dots/.config/quickshell/ii/modules/settings/InterfaceConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/InterfaceConfig.qml
@@ -902,6 +902,23 @@ ContentPage {
     }
 
     ContentSection {
+        icon: "translate"
+        title: Translation.tr("Language switcher notification")
+        tooltip: Translation.tr("To add keyboard layouts (max 4 per device with XKB), set kb_layout in general.lua.\nSet kb_options = \"grp:alt_shift_toggle\" to switch with Alt+Shift.\nRefer to Hyprland wiki documentation for more details.")
+
+        ConfigRow {
+            ConfigSwitch {
+                buttonIcon: "check"
+                text: Translation.tr("Enable switcher notification")
+                checked: Config.options.languageSwitcher.enable ?? true
+                onCheckedChanged: {
+                    Config.options.languageSwitcher.enable = checked;
+                }
+            }
+        }
+    }
+
+    ContentSection {
         icon: "overview_key"
         title: Translation.tr("Overview")
 


### PR DESCRIPTION
## Describe your changes


https://github.com/user-attachments/assets/fed832c7-72f1-4a49-a4a4-cf2d2e89d103


This PR adds a keyboard layout switch OSD notification:

- Integrated into `OnScreenDisplay.qml` (`OsdValueIndicator`), sharing standard OSD placement, window surface, animations, and timeout.
- Added an enable/disable switch under Settings -> Interface -> Language switcher notification with setup guide.

### Setup Nuances:
- Set `kb_layout` in `general.lua` (max 4 per device with XKB).
- Set `kb_options = "grp:alt_shift_toggle"` to switch with Alt+Shift (or add your shortcut in `keybinds.lua`). Refer to Hyprland wiki for details.

## Is it ready? Questions/feedback needed?
Ready to go.

Feature might feel a bit like overengineering, but as someone who types in multiple languages, having the layout OSD right in the center is way easier to catch than checking the bar corner every time.



