### PR TITLE
feat(bluetooth): Fast Pair style popup for nearby devices

### DIFF
--- a/dots/.config/quickshell/ii/GlobalStates.qml
+++ b/dots/.config/quickshell/ii/GlobalStates.qml
@@ -33,6 +33,10 @@ Singleton {
     property bool wallpaperSelectorOpen: false
     property bool workspaceShowNumbers: false
 
+    // Vertical space the notification popups currently take up, so other panels
+    // sharing that corner can move out of their way. 0 when none are showing.
+    property real notificationPopupHeight: 0
+
     property bool dashboardPanelOpen: false // formerly sidebarRightOpen
     property bool policiesPanelOpen: false  // formerly sidebarLeftOpen
 

--- a/dots/.config/quickshell/ii/modules/common/Config.qml
+++ b/dots/.config/quickshell/ii/modules/common/Config.qml
@@ -459,6 +459,20 @@ Singleton {
                 property int suspend: 3
             }
 
+            property JsonObject bluetooth: JsonObject {
+                // Android-style popup offering nearby unpaired devices.
+                // Off by default: it keeps the adapter discovering whenever
+                // nothing is connected, which costs radio time and battery.
+                property JsonObject fastPair: JsonObject {
+                    property bool enable: false
+                    property int rssiThreshold: -65 // dBm; higher means the device must be closer
+                    property bool audioOnly: true // Only offer headsets, earbuds and speakers
+                    property int popupTimeout: 20 // Seconds before the popup snoozes itself; 0 to never
+                    property int snoozeSeconds: 300 // How long a dismissed device stays quiet
+                    property list<string> ignoredDevices: [] // Addresses to never offer again
+                }
+            }
+
             property JsonObject calendar: JsonObject {
                 property string locale: "en-GB"
             }

--- a/dots/.config/quickshell/ii/modules/ii/fastPair/FastPairPopup.qml
+++ b/dots/.config/quickshell/ii/modules/ii/fastPair/FastPairPopup.qml
@@ -41,10 +41,21 @@ Scope {
         // click-through.
         readonly property real sidebarInset: GlobalStates.effectiveRightOpen ? Appearance.sizes.sidebarWidth : 0
 
+        // Notifications own this corner, so drop below them rather than
+        // overlapping. card.y adds the gutter on top of this, which is what
+        // leaves the same gap here as the card keeps from the screen edge.
+        // Clamped so a tall stack cannot push the card off screen.
+        readonly property real notificationInset: {
+            if (GlobalStates.notificationPopupHeight <= 0)
+                return 0;
+            const room = (root.screen?.height ?? 0) - card.height - card.gutter * 2;
+            return Math.max(0, Math.min(GlobalStates.notificationPopupHeight, room));
+        }
+
         // Gutter to the screen edge, elevationMargin of slack on the far side
         // for the shadow: the same split SidebarDashboard uses.
         implicitWidth: card.width + card.gutter + Appearance.sizes.elevationMargin + Appearance.sizes.sidebarWidth
-        implicitHeight: card.height + card.gutter + Appearance.sizes.elevationMargin
+        implicitHeight: card.gutter + root.notificationInset + card.height + Appearance.sizes.elevationMargin
 
         mask: Region {
             item: card
@@ -82,11 +93,15 @@ Scope {
 
             width: 344
             height: content.implicitHeight + card.padding * 2
-            y: card.gutter
+            y: card.gutter + root.notificationInset
             // Slides out past the screen edge, so there is nothing to clip.
             x: FastPair.popupShown ? root.width - card.width - card.gutter - root.sidebarInset : root.width + card.gutter
 
             Behavior on x {
+                animation: Appearance.animation.elementMoveEnter.numberAnimation.createObject(this)
+            }
+
+            Behavior on y {
                 animation: Appearance.animation.elementMoveEnter.numberAnimation.createObject(this)
             }
 

--- a/dots/.config/quickshell/ii/modules/ii/fastPair/FastPairPopup.qml
+++ b/dots/.config/quickshell/ii/modules/ii/fastPair/FastPairPopup.qml
@@ -1,0 +1,256 @@
+pragma ComponentBehavior: Bound
+
+import qs
+import qs.modules.common
+import qs.modules.common.widgets
+import qs.services
+import QtQuick
+import QtQuick.Layouts
+import Quickshell
+import Quickshell.Hyprland
+import Quickshell.Wayland
+
+Scope {
+    id: fastPairPopup
+
+    PanelWindow {
+        id: root
+
+        // Stays mapped until the card has finished sliding back off-screen.
+        visible: (FastPair.popupShown || card.x < root.width) && !GlobalStates.screenLocked
+        screen: Quickshell.screens.find(s => s.name === Hyprland.focusedMonitor?.name) ?? null
+        color: "transparent"
+
+        WlrLayershell.namespace: "quickshell:fastPairPopup"
+        WlrLayershell.layer: WlrLayer.Overlay
+        // Reserve nothing, but do respect what the bar reserves. That is what
+        // puts the card the same distance from the edge as every other panel,
+        // and it handles a vertical or bottom bar without special-casing it.
+        exclusiveZone: 0
+
+        anchors {
+            top: true
+            right: true
+        }
+
+        // Slide inwards so the right sidebar can have the corner, and drift back
+        // out once it closes. This has to move the card rather than the window's
+        // right margin: changing margins does not reconfigure an already
+        // committed layer surface, so the window instead stays put and is made
+        // wide enough to cover both positions. The mask keeps the slack
+        // click-through.
+        readonly property real sidebarInset: GlobalStates.effectiveRightOpen ? Appearance.sizes.sidebarWidth : 0
+
+        // Gutter to the screen edge, elevationMargin of slack on the far side
+        // for the shadow: the same split SidebarDashboard uses.
+        implicitWidth: card.width + card.gutter + Appearance.sizes.elevationMargin + Appearance.sizes.sidebarWidth
+        implicitHeight: card.height + card.gutter + Appearance.sizes.elevationMargin
+
+        mask: Region {
+            item: card
+        }
+
+        Item {
+            id: card
+
+            // Same outer spacing as the sidebars, notifications and bar popups.
+            readonly property real gutter: Appearance.sizes.hyprlandGapsOut
+            readonly property real padding: 24
+            property bool optionsOpen: false
+
+            readonly property bool shown: FastPair.popupShown
+            onShownChanged: if (card.shown) card.optionsOpen = false
+
+            readonly property string statusText: {
+                if (FastPair.failed)
+                    return Translation.tr("Couldn't connect, try again");
+                if (!FastPair.busy)
+                    return Translation.tr("Nearby and ready to pair");
+                if (FastPair.candidate?.connected)
+                    return Translation.tr("Connected");
+                if (FastPair.candidate?.paired)
+                    return Translation.tr("Connecting...");
+                return Translation.tr("Pairing...");
+            }
+
+            readonly property var snoozePresets: [
+                { label: Translation.tr("10m"), ms: 600000 },
+                { label: Translation.tr("30m"), ms: 1800000 },
+                { label: Translation.tr("1h"), ms: 3600000 },
+                { label: Translation.tr("6h"), ms: 21600000 }
+            ]
+
+            width: 344
+            height: content.implicitHeight + card.padding * 2
+            y: card.gutter
+            // Slides out past the screen edge, so there is nothing to clip.
+            x: FastPair.popupShown ? root.width - card.width - card.gutter - root.sidebarInset : root.width + card.gutter
+
+            Behavior on x {
+                animation: Appearance.animation.elementMoveEnter.numberAnimation.createObject(this)
+            }
+
+            StyledRectangularShadow {
+                target: background
+            }
+
+            Rectangle {
+                id: background
+                anchors.fill: parent
+                radius: Appearance.rounding.verylarge
+                color: Appearance.colors.colLayer0
+            }
+
+            component Chip: DialogButton {
+                padding: 10
+                implicitHeight: 32
+            }
+
+            ColumnLayout {
+                id: content
+                anchors {
+                    left: parent.left
+                    right: parent.right
+                    verticalCenter: parent.verticalCenter
+                    leftMargin: card.padding
+                    rightMargin: card.padding
+                }
+                spacing: 6
+
+                StyledText {
+                    Layout.fillWidth: true
+                    horizontalAlignment: Text.AlignHCenter
+                    font.pixelSize: Appearance.font.pixelSize.larger
+                    color: Appearance.colors.colOnLayer0
+                    elide: Text.ElideRight
+                    textFormat: Text.PlainText
+                    text: FastPair.candidate?.name || Translation.tr("Bluetooth device")
+                }
+
+                StyledText {
+                    Layout.fillWidth: true
+                    Layout.bottomMargin: 10
+                    horizontalAlignment: Text.AlignHCenter
+                    wrapMode: Text.Wrap
+                    font.pixelSize: Appearance.font.pixelSize.smaller
+                    color: Appearance.colors.colSubtext
+                    textFormat: Text.PlainText
+                    text: card.statusText
+                }
+
+                MaterialShapeWrappedMaterialSymbol {
+                    Layout.alignment: Qt.AlignHCenter
+                    Layout.bottomMargin: 12
+                    shape: MaterialShape.Shape.Cookie12Sided
+                    iconSize: 72
+                    padding: 32
+                    text: Icons.getBluetoothDeviceMaterialSymbol(FastPair.candidate?.icon ?? "")
+                }
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    Layout.bottomMargin: 10
+                    visible: card.optionsOpen
+                    spacing: 4
+
+                    StyledText {
+                        text: Translation.tr("Snooze this device")
+                        font.pixelSize: Appearance.font.pixelSize.smaller
+                        color: Appearance.colors.colSubtext
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 4
+
+                        Repeater {
+                            model: card.snoozePresets
+
+                            Chip {
+                                required property var modelData
+                                Layout.fillWidth: true
+                                buttonText: modelData.label
+                                onClicked: FastPair.dismiss(modelData.ms)
+                            }
+                        }
+                    }
+
+                    Chip {
+                        Layout.fillWidth: true
+                        Layout.topMargin: 2
+                        colText: Appearance.colors.colError
+                        buttonText: Translation.tr("Never show this device")
+                        onClicked: FastPair.ignoreCandidate()
+                    }
+
+                    StyledText {
+                        Layout.topMargin: 6
+                        text: Translation.tr("Mute all pairing popups")
+                        font.pixelSize: Appearance.font.pixelSize.smaller
+                        color: Appearance.colors.colSubtext
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 4
+
+                        Repeater {
+                            model: card.snoozePresets
+
+                            Chip {
+                                required property var modelData
+                                Layout.fillWidth: true
+                                buttonText: modelData.label
+                                onClicked: FastPair.muteAll(modelData.ms)
+                            }
+                        }
+                    }
+                }
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 8
+
+                    DialogButton {
+                        Layout.fillWidth: true
+                        buttonText: Translation.tr("Close")
+                        onClicked: FastPair.dismiss(FastPair.options.snoozeSeconds * 1000)
+                    }
+
+                    DialogButton {
+                        implicitWidth: 36
+                        padding: 6
+                        onClicked: card.optionsOpen = !card.optionsOpen
+
+                        contentItem: MaterialSymbol {
+                            anchors.centerIn: parent
+                            text: "expand_more"
+                            iconSize: Appearance.font.pixelSize.larger
+                            color: Appearance.colors.colPrimary
+                            rotation: card.optionsOpen ? 180 : 0
+
+                            Behavior on rotation {
+                                animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+                            }
+                        }
+
+                        StyledToolTip {
+                            text: Translation.tr("More options")
+                        }
+                    }
+
+                    DialogButton {
+                        Layout.fillWidth: true
+                        enabled: !FastPair.busy
+                        colBackground: Appearance.colors.colPrimary
+                        colBackgroundHover: Appearance.colors.colPrimaryHover
+                        colRipple: Appearance.colors.colPrimaryActive
+                        colEnabled: Appearance.colors.colOnPrimary
+                        buttonText: Translation.tr("Connect")
+                        onClicked: FastPair.connectCandidate()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/ii/modules/ii/fastPair/FastPairPopup.qml
+++ b/dots/.config/quickshell/ii/modules/ii/fastPair/FastPairPopup.qml
@@ -28,9 +28,14 @@ Scope {
         // and it handles a vertical or bottom bar without special-casing it.
         exclusiveZone: 0
 
+        // Full height on purpose, like NotificationPopup: the card changes height
+        // when the options expand, and resizing a layer surface every animation
+        // frame is what makes that stutter. The mask keeps the slack
+        // click-through.
         anchors {
             top: true
             right: true
+            bottom: true
         }
 
         // Slide inwards so the right sidebar can have the corner, and drift back
@@ -48,14 +53,13 @@ Scope {
         readonly property real notificationInset: {
             if (GlobalStates.notificationPopupHeight <= 0)
                 return 0;
-            const room = (root.screen?.height ?? 0) - card.height - card.gutter * 2;
+            const room = root.height - card.height - card.gutter * 2;
             return Math.max(0, Math.min(GlobalStates.notificationPopupHeight, room));
         }
 
         // Gutter to the screen edge, elevationMargin of slack on the far side
         // for the shadow: the same split SidebarDashboard uses.
         implicitWidth: card.width + card.gutter + Appearance.sizes.elevationMargin + Appearance.sizes.sidebarWidth
-        implicitHeight: card.gutter + root.notificationInset + card.height + Appearance.sizes.elevationMargin
 
         mask: Region {
             item: card
@@ -162,61 +166,72 @@ Scope {
                     text: Icons.getBluetoothDeviceMaterialSymbol(FastPair.candidate?.icon ?? "")
                 }
 
-                ColumnLayout {
+                // Revealer clips and animates the reveal rather than snapping the
+                // card to a new height. Held visible at zero height so the
+                // layout's spacing does not pop once it finishes collapsing.
+                Revealer {
                     Layout.fillWidth: true
-                    Layout.bottomMargin: 10
-                    visible: card.optionsOpen
-                    spacing: 4
+                    vertical: true
+                    reveal: card.optionsOpen
+                    visible: true
 
-                    StyledText {
-                        text: Translation.tr("Snooze this device")
-                        font.pixelSize: Appearance.font.pixelSize.smaller
-                        color: Appearance.colors.colSubtext
-                    }
-
-                    RowLayout {
-                        Layout.fillWidth: true
+                    ColumnLayout {
+                        // Explicit width: taking it from the Revealer would make
+                        // the Revealer's implicitWidth depend on its own child.
+                        width: card.width - card.padding * 2
                         spacing: 4
 
-                        Repeater {
-                            model: card.snoozePresets
+                        StyledText {
+                            text: Translation.tr("Snooze this device")
+                            font.pixelSize: Appearance.font.pixelSize.smaller
+                            color: Appearance.colors.colSubtext
+                        }
 
-                            Chip {
-                                required property var modelData
-                                Layout.fillWidth: true
-                                buttonText: modelData.label
-                                onClicked: FastPair.dismiss(modelData.ms)
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: 4
+
+                            Repeater {
+                                model: card.snoozePresets
+
+                                Chip {
+                                    required property var modelData
+                                    Layout.fillWidth: true
+                                    buttonText: modelData.label
+                                    onClicked: FastPair.dismiss(modelData.ms)
+                                }
                             }
                         }
-                    }
 
-                    Chip {
-                        Layout.fillWidth: true
-                        Layout.topMargin: 2
-                        colText: Appearance.colors.colError
-                        buttonText: Translation.tr("Never show this device")
-                        onClicked: FastPair.ignoreCandidate()
-                    }
+                        Chip {
+                            Layout.fillWidth: true
+                            Layout.topMargin: 2
+                            colText: Appearance.colors.colError
+                            buttonText: Translation.tr("Never show this device")
+                            onClicked: FastPair.ignoreCandidate()
+                        }
 
-                    StyledText {
-                        Layout.topMargin: 6
-                        text: Translation.tr("Mute all pairing popups")
-                        font.pixelSize: Appearance.font.pixelSize.smaller
-                        color: Appearance.colors.colSubtext
-                    }
+                        StyledText {
+                            Layout.topMargin: 6
+                            text: Translation.tr("Mute all pairing popups")
+                            font.pixelSize: Appearance.font.pixelSize.smaller
+                            color: Appearance.colors.colSubtext
+                        }
 
-                    RowLayout {
-                        Layout.fillWidth: true
-                        spacing: 4
+                        RowLayout {
+                            Layout.bottomMargin: 10
+                            Layout.fillWidth: true
+                            spacing: 4
 
-                        Repeater {
-                            model: card.snoozePresets
+                            Repeater {
+                                model: card.snoozePresets
 
-                            Chip {
-                                required property var modelData
-                                Layout.fillWidth: true
-                                buttonText: modelData.label
-                                onClicked: FastPair.muteAll(modelData.ms)
+                                Chip {
+                                    required property var modelData
+                                    Layout.fillWidth: true
+                                    buttonText: modelData.label
+                                    onClicked: FastPair.muteAll(modelData.ms)
+                                }
                             }
                         }
                     }

--- a/dots/.config/quickshell/ii/modules/ii/fastPair/FastPairPopup.qml
+++ b/dots/.config/quickshell/ii/modules/ii/fastPair/FastPairPopup.qml
@@ -77,6 +77,9 @@ Scope {
             onShownChanged: if (card.shown) card.optionsOpen = false
 
             readonly property string statusText: {
+                // Names the binary rather than any one distro's package name.
+                if (FastPair.agentUnavailable)
+                    return Translation.tr("Can't pair: bluetoothctl not available");
                 if (FastPair.failed)
                     return Translation.tr("Couldn't connect, try again");
                 if (!FastPair.busy)

--- a/dots/.config/quickshell/ii/modules/ii/notificationPopup/NotificationPopup.qml
+++ b/dots/.config/quickshell/ii/modules/ii/notificationPopup/NotificationPopup.qml
@@ -45,5 +45,14 @@ Scope {
             implicitWidth: parent.width - Appearance.sizes.elevationMargin * 2
             popup: true
         }
+
+        // Published so panels in the same corner can shift out of the way.
+        // Clamped to what actually fits on screen, so a long stack cannot push
+        // them off the display.
+        Binding {
+            target: GlobalStates
+            property: "notificationPopupHeight"
+            value: root.visible ? listview.y + Math.min(listview.contentHeight, listview.height) : 0
+        }
     }
 }

--- a/dots/.config/quickshell/ii/modules/settings/ServicesConfig.qml
+++ b/dots/.config/quickshell/ii/modules/settings/ServicesConfig.qml
@@ -28,6 +28,68 @@ ContentPage {
     }
 
     ContentSection {
+        icon: "bluetooth_searching"
+        title: Translation.tr("Fast pairing")
+
+        ConfigSwitch {
+            buttonIcon: "check"
+            text: Translation.tr("Offer nearby devices for pairing")
+            checked: Config.options.bluetooth.fastPair.enable
+            onCheckedChanged: {
+                Config.options.bluetooth.fastPair.enable = checked;
+            }
+            StyledToolTip {
+                text: Translation.tr("Shows an Android-style card when an unpaired device is nearby. Keeps Bluetooth discovering whenever nothing is connected, which costs radio time and battery.")
+            }
+        }
+
+        ConfigSwitch {
+            buttonIcon: "headphones"
+            text: Translation.tr("Audio devices only")
+            checked: Config.options.bluetooth.fastPair.audioOnly
+            onCheckedChanged: {
+                Config.options.bluetooth.fastPair.audioOnly = checked;
+            }
+            StyledToolTip {
+                text: Translation.tr("Ignore watches, phones and anything else that is not a headset or speaker")
+            }
+        }
+
+        ConfigSpinBox {
+            icon: "settings_input_antenna"
+            text: Translation.tr("Minimum signal strength (dBm)")
+            value: Config.options.bluetooth.fastPair.rssiThreshold
+            from: -95
+            to: -35
+            stepSize: 5
+            onValueChanged: {
+                Config.options.bluetooth.fastPair.rssiThreshold = value;
+            }
+        }
+
+        ConfigSpinBox {
+            icon: "timer"
+            text: Translation.tr("Popup timeout (s)")
+            value: Config.options.bluetooth.fastPair.popupTimeout
+            from: 0
+            to: 120
+            stepSize: 5
+            onValueChanged: {
+                Config.options.bluetooth.fastPair.popupTimeout = value;
+            }
+        }
+
+        RippleButtonWithIcon {
+            visible: Config.options.bluetooth.fastPair.ignoredDevices.length > 0
+            materialIcon: "playlist_remove"
+            mainText: Translation.tr("Clear %1 ignored device(s)").arg(Config.options.bluetooth.fastPair.ignoredDevices.length)
+            onClicked: {
+                Config.options.bluetooth.fastPair.ignoredDevices = [];
+            }
+        }
+    }
+
+    ContentSection {
         icon: "album"
         title: Translation.tr("Media")
 

--- a/dots/.config/quickshell/ii/panelFamilies/IllogicalImpulseFamily.qml
+++ b/dots/.config/quickshell/ii/panelFamilies/IllogicalImpulseFamily.qml
@@ -6,6 +6,7 @@ import qs.modules.ii.background
 import qs.modules.ii.bar
 import qs.modules.ii.cheatsheet
 import qs.modules.ii.dock
+import qs.modules.ii.fastPair
 import qs.modules.ii.lock
 import qs.modules.ii.mediaControls
 import qs.modules.ii.notificationPopup
@@ -46,6 +47,7 @@ Scope {
     PanelLoader { extraCondition: Config.options.background.enable; component: Background {} }
     PanelLoader { component: Cheatsheet {} }
     PanelLoader { extraCondition: Config.options.dock.enable; component: Dock {} }
+    PanelLoader { extraCondition: Config.options.bluetooth.fastPair.enable; component: FastPairPopup {} }
     PanelLoader { component: Lock {} }
     PanelLoader { component: MediaControls {} }
     PanelLoader { component: NotificationPopup {} }

--- a/dots/.config/quickshell/ii/services/FastPair.qml
+++ b/dots/.config/quickshell/ii/services/FastPair.qml
@@ -29,6 +29,10 @@ Singleton {
     // popupShown: closing the card must not abort a connect already running.
     property bool busy: false
     property bool failed: false
+    // No pairing agent could be brought up, which on most systems means
+    // bluetoothctl is not installed. Worth telling the user apart from an
+    // ordinary failure, since nothing they do to the device will help.
+    property bool agentUnavailable: false
 
     // address -> advert, straight from BlueZ. See fastPairAdverts.js.
     property var adverts: ({})
@@ -72,6 +76,7 @@ Singleton {
         root.candidate = best;
         root.busy = false;
         root.failed = false;
+        root.agentUnavailable = false;
         root.popupShown = true;
         if (root.options.popupTimeout > 0)
             autoDismiss.restart();
@@ -86,6 +91,7 @@ Singleton {
         // unreliable.
         root.busy = true;
         root.failed = false;
+        root.agentUnavailable = false;
         connectTimeout.restart();
         // Trusting up front stops BlueZ asking the agent to authorize the
         // service, which the borrowed bluetoothctl agent would only prompt for
@@ -107,6 +113,20 @@ Singleton {
 
     function releaseAgent() {
         pairingAgent.running = false;
+    }
+
+    // One place to end a failed attempt. busy is cleared first so that releasing
+    // the agent cannot re-enter this through pairingAgent's onRunningChanged.
+    function abandon() {
+        if (!root.busy)
+            return;
+        root.busy = false;
+        connectTimeout.stop();
+        settle.stop();
+        root.releaseAgent();
+        root.failed = true;
+        if (root.popupShown && root.options.popupTimeout > 0)
+            autoDismiss.restart();
     }
 
     // Hides the card. UI only: an in-flight attempt keeps running.
@@ -198,13 +218,8 @@ Singleton {
         onTriggered: {
             if (!root.busy)
                 return;
-            settle.stop();
             console.warn("FastPair: gave up on", root.candidate?.name ?? "device", "- paired =", root.candidate?.paired ?? false, "connected =", root.candidate?.connected ?? false);
-            root.releaseAgent();
-            root.busy = false;
-            root.failed = true;
-            if (root.popupShown && root.options.popupTimeout > 0)
-                autoDismiss.restart();
+            root.abandon();
         }
     }
 
@@ -269,7 +284,20 @@ Singleton {
         command: ["bluetoothctl", "--agent", "NoInputNoOutput"]
         stdinEnabled: true
         onStarted: pairingAgent.write("default-agent\n")
-        onRunningChanged: if (!pairingAgent.running) pairingAgent.agentReady = false
+        onRunningChanged: {
+            if (pairingAgent.running)
+                return;
+            pairingAgent.agentReady = false;
+            if (!root.busy)
+                return;
+            // Quickshell emits no exited signal for a binary it could not find,
+            // it just puts running back to false, so this is also how
+            // "bluetoothctl is not installed" arrives. Fail now rather than
+            // letting the attempt sit there until connectTimeout.
+            console.warn("FastPair: pairing agent went away - is bluetoothctl installed?");
+            root.agentUnavailable = true;
+            root.abandon();
+        }
         stdout: SplitParser {
             onRead: line => {
                 if (pairingAgent.agentReady || !line.includes("Agent registered"))

--- a/dots/.config/quickshell/ii/services/FastPair.qml
+++ b/dots/.config/quickshell/ii/services/FastPair.qml
@@ -246,8 +246,11 @@ Singleton {
         onTriggered: root.applyScanState()
     }
 
+    // Discovery can also be running because the user opened the Bluetooth dialog,
+    // so this checks the option too: the singleton outlives the popup when the
+    // option is switched off, and must go quiet rather than keep polling.
     Timer {
-        running: (root.adapter?.discovering ?? false) && !root.popupShown
+        running: root.options.enable && (root.adapter?.discovering ?? false) && !root.popupShown
         repeat: true
         interval: 2000
         triggeredOnStart: true

--- a/dots/.config/quickshell/ii/services/FastPair.qml
+++ b/dots/.config/quickshell/ii/services/FastPair.qml
@@ -1,0 +1,293 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import "fastPairAdverts.js" as Adverts
+import qs.modules.common
+import qs.services
+import QtQuick
+import Quickshell
+import Quickshell.Bluetooth
+import Quickshell.Io
+
+/**
+ * Offers nearby unpaired Bluetooth devices for one-tap pairing, like Android's
+ * Fast Pair. Drives modules/ii/fastPair/FastPairPopup.qml.
+ *
+ * Off by default: it keeps the adapter discovering for as long as nothing is
+ * connected, which costs radio time and battery.
+ */
+Singleton {
+    id: root
+
+    readonly property var options: Config.options.bluetooth.fastPair
+    readonly property BluetoothAdapter adapter: Bluetooth.defaultAdapter
+
+    // Device currently being offered, and whether the card is up.
+    property BluetoothDevice candidate: null
+    property bool popupShown: false
+    // A pair/connect attempt is in flight. Deliberately independent of
+    // popupShown: closing the card must not abort a connect already running.
+    property bool busy: false
+    property bool failed: false
+
+    // address -> advert, straight from BlueZ. See fastPairAdverts.js.
+    property var adverts: ({})
+    // address -> ms timestamp before which a device must not be offered again.
+    // Dismissing is a snooze, never a blacklist: closing the card means "not
+    // now", and earbuds sitting in pairing mode are worth offering again later.
+    // Permanent ignores go in options.ignoredDevices instead.
+    property var suppressedUntil: ({})
+    // Wall-clock ms before which nothing at all is offered.
+    property real mutedUntil: 0
+
+    // An unresolved name is just the MAC, which is nothing worth offering.
+    readonly property var macNameRegex: /^([0-9A-Fa-f]{2}[-:]){5}[0-9A-Fa-f]{2}$/
+
+    function pickCandidate() {
+        if (root.popupShown || Date.now() < root.mutedUntil)
+            return;
+        let best = null;
+        let bestRssi = -999;
+        for (const device of (Bluetooth.devices?.values ?? [])) {
+            if (!device || device.paired || device.connected || device.pairing)
+                continue;
+            if ((root.suppressedUntil[device.address] ?? 0) > Date.now())
+                continue;
+            if (root.options.ignoredDevices.includes(device.address))
+                continue;
+            if (root.macNameRegex.test(device.name ?? ""))
+                continue;
+            const advert = root.adverts[device.address];
+            if (!advert || advert.rssi < root.options.rssiThreshold)
+                continue;
+            if (root.options.audioOnly && !advert.audio)
+                continue;
+            if (advert.rssi > bestRssi) {
+                best = device;
+                bestRssi = advert.rssi;
+            }
+        }
+        if (!best)
+            return;
+        root.candidate = best;
+        root.busy = false;
+        root.failed = false;
+        root.popupShown = true;
+        if (root.options.popupTimeout > 0)
+            autoDismiss.restart();
+    }
+
+    function connectCandidate() {
+        const device = root.candidate;
+        if (!device)
+            return;
+        autoDismiss.stop();
+        // Drops shouldScan, which stops discovery: pairing during an inquiry is
+        // unreliable.
+        root.busy = true;
+        root.failed = false;
+        connectTimeout.restart();
+        // Trusting up front stops BlueZ asking the agent to authorize the
+        // service, which the borrowed bluetoothctl agent would only prompt for
+        // on a pipe nobody reads. It is also what makes the device reconnect on
+        // its own next time, which is the half of Fast Pair that matters most.
+        device.trusted = true;
+        if (device.paired)
+            return; // connectRetry takes it from here
+        pairingAgent.running = true;
+    }
+
+    // Ends the attempt. Only reached once the link has actually held.
+    function finishConnect() {
+        console.log("FastPair: connected", root.candidate?.name ?? "device");
+        root.busy = false;
+        root.releaseAgent();
+        root.dismiss(0);
+    }
+
+    function releaseAgent() {
+        pairingAgent.running = false;
+    }
+
+    // Hides the card. UI only: an in-flight attempt keeps running.
+    function dismiss(suppressMs) {
+        if (suppressMs > 0 && root.candidate) {
+            let next = Object.assign({}, root.suppressedUntil);
+            next[root.candidate.address] = Date.now() + suppressMs;
+            root.suppressedUntil = next;
+        }
+        autoDismiss.stop();
+        root.popupShown = false;
+    }
+
+    function muteAll(ms) {
+        root.mutedUntil = Date.now() + ms;
+        root.dismiss(0);
+    }
+
+    // Unlike a snooze, this survives a restart.
+    function ignoreCandidate() {
+        const address = root.candidate?.address;
+        if (address && !root.options.ignoredDevices.includes(address))
+            root.options.ignoredDevices = [...root.options.ignoredDevices, address];
+        root.dismiss(0);
+    }
+
+    Connections {
+        target: root.candidate
+        enabled: root.candidate !== null
+
+        // BlueZ raises the link during pairing and then tears it down a few
+        // seconds later, so the first "connected" is not the real one. Wait for
+        // it to hold before closing the card, otherwise connectRetry gets
+        // switched off right before the drop it exists to catch.
+        function onConnectedChanged() {
+            if (!root.busy)
+                return;
+            if (!root.candidate?.connected) {
+                settle.stop();
+                return;
+            }
+            settle.restart();
+        }
+    }
+
+    Timer {
+        id: settle
+        interval: 9000
+        onTriggered: {
+            if (root.candidate?.connected)
+                root.finishConnect();
+        }
+    }
+
+    // Pair() fails outright with "Page Timeout" when the device does not answer
+    // the page, which is routine while earbuds settle into pairing mode. Keep
+    // asking for as long as the attempt is alive.
+    Timer {
+        id: pairRetry
+        running: root.busy && pairingAgent.agentReady && root.candidate && !root.candidate.paired
+        repeat: true
+        interval: 5000
+        triggeredOnStart: true
+        onTriggered: {
+            console.log("FastPair: pairing", root.candidate.name);
+            root.candidate.pair();
+        }
+    }
+
+    // Pair() returns before BlueZ has finished SDP, and the link drops once more
+    // after bonding, so a single Connect() is never enough. Quickshell exposes
+    // no ServicesResolved, so keep asking until it holds or connectTimeout gives
+    // up.
+    Timer {
+        id: connectRetry
+        running: root.busy && root.candidate && root.candidate.paired && !root.candidate.connected
+        repeat: true
+        interval: 2000
+        triggeredOnStart: true
+        onTriggered: {
+            console.log("FastPair: connecting", root.candidate.name);
+            root.candidate.connect();
+        }
+    }
+
+    Timer {
+        id: connectTimeout
+        interval: 60000
+        onTriggered: {
+            if (!root.busy)
+                return;
+            settle.stop();
+            console.warn("FastPair: gave up on", root.candidate?.name ?? "device", "- paired =", root.candidate?.paired ?? false, "connected =", root.candidate?.connected ?? false);
+            root.releaseAgent();
+            root.busy = false;
+            root.failed = true;
+            if (root.popupShown && root.options.popupTimeout > 0)
+                autoDismiss.restart();
+        }
+    }
+
+    Timer {
+        id: autoDismiss
+        interval: 1000 * root.options.popupTimeout
+        onTriggered: root.dismiss(root.options.snoozeSeconds * 1000)
+    }
+
+    // Discovery just runs whenever the adapter is idle. Short scan windows do
+    // not work: a BR/EDR inquiry round takes ~10s, so a few seconds of scanning
+    // turns up BLE beacons and misses the earbuds. It still stops the moment
+    // anything connects, since scanning stutters A2DP.
+    readonly property bool shouldScan: Config.ready && root.options.enable && (root.adapter?.enabled ?? false) && !BluetoothStatus.connected && !root.busy
+
+    function applyScanState() {
+        if (!root.adapter)
+            return;
+        // No ownership tracking: Quickshell shares one D-Bus connection across
+        // the whole shell, so our discovery reference cannot be told apart from
+        // the Bluetooth dialog's. Both cases where this stops scanning (pairing,
+        // and a device connecting) are reasons to stop anyway.
+        root.adapter.discovering = root.shouldScan;
+    }
+
+    onShouldScanChanged: root.applyScanState()
+    onAdapterChanged: root.applyScanState()
+    Component.onCompleted: root.applyScanState()
+
+    // Quickshell's discovering setter is fire-and-forget, and BlueZ answers
+    // "Resource Not Ready" while the adapter is still coming up, so one bad
+    // moment at startup would otherwise kill discovery for the whole session.
+    // Re-assert until it sticks; this also covers BlueZ dropping discovery on
+    // its own. Costs nothing once scanning, since running goes false.
+    Timer {
+        running: root.shouldScan && !(root.adapter?.discovering ?? false)
+        repeat: true
+        interval: 3000
+        onTriggered: root.applyScanState()
+    }
+
+    Timer {
+        running: (root.adapter?.discovering ?? false) && !root.popupShown
+        repeat: true
+        interval: 2000
+        triggeredOnStart: true
+        onTriggered: busctlDump.running = true
+    }
+
+    // Quickshell implements no org.bluez.Agent1 (only Adapter1, Device1 and
+    // Battery1) and BlueZ refuses to pair when no agent is registered anywhere
+    // on the bus, so Pair() fails silently on a system with no blueman or
+    // bluedevil running. bluetoothctl brings its own agent. Borrow it only for
+    // the duration of the pairing, so a system that does have a proper agent
+    // (one that can actually show a PIN) keeps it as the default.
+    Process {
+        id: pairingAgent
+        property bool agentReady: false
+        command: ["bluetoothctl", "--agent", "NoInputNoOutput"]
+        stdinEnabled: true
+        onStarted: pairingAgent.write("default-agent\n")
+        onRunningChanged: if (!pairingAgent.running) pairingAgent.agentReady = false
+        stdout: SplitParser {
+            onRead: line => {
+                if (pairingAgent.agentReady || !line.includes("Agent registered"))
+                    return;
+                pairingAgent.agentReady = true;
+            }
+        }
+    }
+
+    Process {
+        id: busctlDump
+        command: ["busctl", "--system", "--json=short", "call", "org.bluez", "/", "org.freedesktop.DBus.ObjectManager", "GetManagedObjects"]
+        stdout: StdioCollector {
+            id: dumpCollector
+            onStreamFinished: {
+                const parsed = Adverts.parseAdverts(dumpCollector.text);
+                if (!parsed)
+                    return; // busctl raced or failed; keep the previous map
+                root.adverts = parsed;
+                root.pickCandidate();
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/ii/services/fastPairAdverts.js
+++ b/dots/.config/quickshell/ii/services/fastPairAdverts.js
@@ -1,0 +1,74 @@
+// Parses `busctl --system --json=short call org.bluez / \
+//   org.freedesktop.DBus.ObjectManager GetManagedObjects` into an advert map,
+// keyed by address so entries can be matched back to Bluetooth.devices.
+//
+// Quickshell.Bluetooth exposes no RSSI, ServiceData or ManufacturerData, so the
+// proximity and Fast Pair signals have to be read from BlueZ directly. Used by
+// FastPair.qml; fastPairAdverts.test.js checks it with `node`.
+
+var FAST_PAIR_UUID = "0000fe2c-";
+var CLASS_MAJOR_AUDIO = 0x04;
+
+function hex2(b) {
+    return ("0" + (b & 0xff).toString(16)).slice(-2);
+}
+
+// Fast Pair service data is one version/flags byte then a 3-byte model ID.
+// Shorter payloads are the non-discoverable (account key filter) frame, which
+// carries no model ID, so those only mean "this is a Fast Pair device".
+function fastPairModelId(serviceData) {
+    for (var uuid in serviceData) {
+        if (uuid.indexOf(FAST_PAIR_UUID) !== 0)
+            continue;
+        var bytes = (serviceData[uuid] && serviceData[uuid].data) || [];
+        if (bytes.length < 4)
+            return "";
+        return hex2(bytes[1]) + hex2(bytes[2]) + hex2(bytes[3]);
+    }
+    return null; // no Fast Pair advert at all
+}
+
+function parseAdverts(text) {
+    var payload;
+    try {
+        payload = JSON.parse(text);
+    } catch (e) {
+        return null; // busctl failed or raced; caller keeps the previous map
+    }
+    var objects = payload && payload.data && payload.data[0];
+    if (!objects)
+        return null;
+
+    var out = {};
+    for (var path in objects) {
+        var dev = objects[path]["org.bluez.Device1"];
+        if (!dev)
+            continue;
+        var address = dev.Address && dev.Address.data;
+        // No RSSI means BlueZ has the device cached but has not seen it in this
+        // discovery session, i.e. it is not actually nearby right now.
+        var rssi = dev.RSSI && dev.RSSI.data;
+        if (!address || rssi === undefined || rssi === null)
+            continue;
+
+        var icon = (dev.Icon && dev.Icon.data) || "";
+        var cod = (dev.Class && dev.Class.data) || 0;
+        var model = fastPairModelId((dev.ServiceData && dev.ServiceData.data) || {});
+
+        out[address] = {
+            address: address,
+            rssi: rssi,
+            icon: icon,
+            fastPair: model !== null,
+            fastPairModel: model || "",
+            // Class of Device bits 8-12 are the major device class, and 0x04 is
+            // Audio/Video. BLE-only earbuds often advertise no CoD at all,
+            // hence the icon and Fast Pair fallbacks.
+            audio: icon.indexOf("audio-") === 0 || ((cod >> 8) & 0x1f) === CLASS_MAJOR_AUDIO || model !== null
+        };
+    }
+    return out;
+}
+
+if (typeof module !== "undefined")
+    module.exports = { parseAdverts: parseAdverts, fastPairModelId: fastPairModelId };

--- a/dots/.config/quickshell/ii/services/fastPairAdverts.test.js
+++ b/dots/.config/quickshell/ii/services/fastPairAdverts.test.js
@@ -1,0 +1,213 @@
+// node services/fastPairAdverts.test.js
+// Real `busctl GetManagedObjects` dump from a live scan (trimmed to the
+// properties the parser reads), plus one synthetic Fast Pair advert since no
+// Fast Pair device was in range when it was captured.
+const assert = require("assert");
+const { parseAdverts, fastPairModelId } = require("./fastPairAdverts.js");
+
+const DUMP = {
+        "type": "a{oa{sa{sv}}}",
+        "data": [
+            {
+                "/org/bluez/hci0/dev_5E_93_DA_26_66_05": {
+                    "org.bluez.Device1": {
+                        "Address": {
+                            "type": "s",
+                            "data": "5E:93:DA:26:66:05"
+                        },
+                        "RSSI": {
+                            "type": "n",
+                            "data": -95
+                        }
+                    }
+                },
+                "/org/bluez/hci0/dev_53_6F_83_76_14_CF": {
+                    "org.bluez.Device1": {
+                        "Address": {
+                            "type": "s",
+                            "data": "53:6F:83:76:14:CF"
+                        },
+                        "RSSI": {
+                            "type": "n",
+                            "data": -89
+                        },
+                        "Icon": {
+                            "type": "s",
+                            "data": "audio-headset"
+                        },
+                        "Class": {
+                            "type": "u",
+                            "data": 2360324
+                        },
+                        "Name": {
+                            "type": "s",
+                            "data": "BT Speaker"
+                        }
+                    }
+                },
+                "/org/bluez/hci0/dev_74_19_0A_2F_1E_9B": {
+                    "org.bluez.Device1": {
+                        "Address": {
+                            "type": "s",
+                            "data": "74:19:0A:2F:1E:9B"
+                        },
+                        "RSSI": {
+                            "type": "n",
+                            "data": -57
+                        },
+                        "Name": {
+                            "type": "s",
+                            "data": "Galaxy Fit3 (1E9B)"
+                        },
+                        "ServiceData": {
+                            "type": "a{sv}",
+                            "data": {
+                                "0000fd69-0000-1000-8000-00805f9b34fb": {
+                                    "type": "ay",
+                                    "data": [
+                                        0,
+                                        222,
+                                        231,
+                                        70,
+                                        53,
+                                        92,
+                                        144,
+                                        20,
+                                        39,
+                                        205,
+                                        153,
+                                        29,
+                                        39,
+                                        88,
+                                        0
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                "/org/bluez/hci0/dev_34_FC_99_FF_6A_78": {
+                    "org.bluez.Device1": {
+                        "Address": {
+                            "type": "s",
+                            "data": "34:FC:99:FF:6A:78"
+                        },
+                        "RSSI": {
+                            "type": "n",
+                            "data": -97
+                        },
+                        "Name": {
+                            "type": "s",
+                            "data": "Washer"
+                        }
+                    }
+                },
+                "/org/bluez/hci0/dev_A8_E2_91_48_B5_83": {
+                    "org.bluez.Device1": {
+                        "Address": {
+                            "type": "s",
+                            "data": "A8:E2:91:48:B5:83"
+                        },
+                        "RSSI": {
+                            "type": "n",
+                            "data": -97
+                        },
+                        "Icon": {
+                            "type": "s",
+                            "data": "computer"
+                        },
+                        "Class": {
+                            "type": "u",
+                            "data": 3031300
+                        },
+                        "Name": {
+                            "type": "s",
+                            "data": "APPAN"
+                        }
+                    }
+                },
+                "/org/bluez/hci0/dev_2C_DE_DF_0C_16_C3": {
+                    "org.bluez.Device1": {
+                        "Address": {
+                            "type": "s",
+                            "data": "2C:DE:DF:0C:16:C3"
+                        },
+                        "Icon": {
+                            "type": "s",
+                            "data": "audio-headset"
+                        },
+                        "Class": {
+                            "type": "u",
+                            "data": 2393092
+                        },
+                        "Name": {
+                            "type": "s",
+                            "data": "Nirvana Ion"
+                        }
+                    }
+                },
+                "/org/bluez/hci0/dev_11_22_33_44_55_66": {
+                    "org.bluez.Device1": {
+                        "Address": {
+                            "type": "s",
+                            "data": "11:22:33:44:55:66"
+                        },
+                        "RSSI": {
+                            "type": "n",
+                            "data": -52
+                        },
+                        "Name": {
+                            "type": "s",
+                            "data": "11-22-33-44-55-66"
+                        },
+                        "ServiceData": {
+                            "type": "a{sv}",
+                            "data": {
+                                "0000fe2c-0000-1000-8000-00805f9b34fb": {
+                                    "type": "ay",
+                                    "data": [
+                                        0,
+                                        14,
+                                        48,
+                                        196
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ]
+    };
+
+const a = parseAdverts(JSON.stringify(DUMP));
+
+// Paired headset was in BlueZ's cache but carried no RSSI -> not nearby now.
+assert.ok(!("2C:DE:DF:0C:16:C3" in a), "device without RSSI must be dropped");
+
+// BR/EDR speaker: CoD 0x240404 -> major class 0x04, icon audio-headset.
+assert.strictEqual(a["53:6F:83:76:14:CF"].rssi, -89);
+assert.strictEqual(a["53:6F:83:76:14:CF"].audio, true);
+assert.strictEqual(a["53:6F:83:76:14:CF"].fastPair, false);
+
+// Samsung watch advertises service data 0xFD69, not 0xFE2C, and has no CoD.
+assert.strictEqual(a["74:19:0A:2F:1E:9B"].audio, false, "watch must not look like earbuds");
+assert.strictEqual(a["74:19:0A:2F:1E:9B"].fastPair, false);
+
+// A laptop (icon "computer") must not qualify either.
+assert.strictEqual(a["A8:E2:91:48:B5:83"].audio, false);
+
+// Fast Pair advert: audio by virtue of FE2C, model ID from bytes 1..3.
+assert.strictEqual(a["11:22:33:44:55:66"].fastPair, true);
+assert.strictEqual(a["11:22:33:44:55:66"].audio, true);
+assert.strictEqual(a["11:22:33:44:55:66"].fastPairModel, "0e30c4");
+
+// Non-discoverable Fast Pair frame: flagged, but no model ID.
+assert.strictEqual(fastPairModelId({ "0000fe2c-0000-1000-8000-00805f9b34fb": { data: [0, 1] } }), "");
+assert.strictEqual(fastPairModelId({ "0000fd69-0000-1000-8000-00805f9b34fb": { data: [0, 1, 2, 3] } }), null);
+
+// Garbage in, previous state preserved (null), not a crash.
+assert.strictEqual(parseAdverts("busctl: command not found"), null);
+assert.strictEqual(parseAdverts('{"type":"x"}'), null);
+
+console.log("ok - " + Object.keys(a).length + " adverts parsed, all assertions passed");

--- a/sdata/dist-arch/illogical-impulse-basic/PKGBUILD
+++ b/sdata/dist-arch/illogical-impulse-basic/PKGBUILD
@@ -15,6 +15,7 @@ depends=(
   ripgrep
   jq
   xdg-user-dirs
+  bluez-utils # bluetoothctl: provides the BlueZ pairing agent the shell borrows
   # Used in install script
   rsync
   go-yq # https://github.com/mikefarah/yq


### PR DESCRIPTION
## Describe your changes

Closes #55. Shows a card in the top right when an unpaired Bluetooth device is
nearby, with one button that pairs, trusts and connects it, then dismisses itself.
It moves aside for the right sidebar and for notification popups.

Off by default (`bluetooth.fastPair.enable`), since it keeps the adapter
discovering whenever nothing is connected. Settings are under Services → Fast
pairing.

Two shell-outs, both because Quickshell doesn't cover them. RSSI comes from BlueZ
via `busctl`, as `Quickshell.Bluetooth` exposes no RSSI and without a proximity
filter the card fires for everything discoverable in range. Pairing borrows
`bluetoothctl --agent NoInputNoOutput` for its duration, because Quickshell
implements no `org.bluez.Agent1` and BlueZ won't pair with no agent on the bus.
That last one is also why the existing Bluetooth dialog can't pair, so I added
`bluez-utils` to `illogical-impulse-basic` — it wasn't a dependency before.

## Is it ready? Questions/feedback needed?

Not quite. I would like more testers for this, and as you can see, it's full-blown AI, so I would like someone to review the code.  
Other than that, I tested it on Arch/Hyprland with a BR/EDR headset. The default RSSI threshold is tuned for one adapter, so it may require a different value.