### PR TITLE
fix(translator): put action buttons inside the ButtonGroup layout

### DIFF
--- a/dots/.config/quickshell/ii/modules/common/widgets/ButtonGroup.qml
+++ b/dots/.config/quickshell/ii/modules/common/widgets/ButtonGroup.qml
@@ -18,12 +18,16 @@ Rectangle {
 
     property real contentWidth: {
         let total = 0;
+        let shown = 0;
         for (let i = 0; i < rowLayout.children.length; ++i) {
             const child = rowLayout.children[i];
             if (!child.visible) continue;
             total += child.baseWidth ?? child.implicitWidth ?? child.width;
+            shown += 1;
         }
-        return total + rowLayout.spacing * (rowLayout.children.length - 1);
+        // Guard the empty case: spacing * (0 - 1) used to make this negative.
+        if (shown === 0) return 0;
+        return total + rowLayout.spacing * (shown - 1);
     }
 
     topLeftRadius: rowLayout.children.length > 0 ? (rowLayout.children[0].radius + padding) : 

--- a/dots/.config/quickshell/ii/modules/ii/sidebarPolicies/translator/TextCanvas.qml
+++ b/dots/.config/quickshell/ii/modules/ii/sidebarPolicies/translator/TextCanvas.qml
@@ -14,7 +14,7 @@ Rectangle {
     property var inputTextArea: isInput ? inputLoader.item : undefined
     readonly property string displayedText: isInput ? inputLoader.item.text : 
         root.text.length > 0 ? outputLoader.item.text : ""
-    default property alias actionButtons: actions.data
+    default property alias actionButtons: actions.groupData
     Layout.fillWidth: true
     implicitHeight: Math.max(150, inputColumn.implicitHeight)
     color: Appearance.colors.colLayer2


### PR DESCRIPTION
### Problem

`translator/TextCanvas.qml:17` declares:

```qml
default property alias actionButtons: actions.data
```

`actions` is a `ButtonGroup`, whose own default property is
`groupData`, aliased to the inner `RowLayout`'s `data`:

```qml
// ButtonGroup.qml:12
default property alias groupData: rowLayout.data
```

Writing to `actions.data` bypasses that and makes the `GroupButton`s direct
children of the `ButtonGroup` **Rectangle**, siblings of the `RowLayout`
rather than children of it. Two consequences:

1. No layout is applied, so every action button stacks at (0, 0).
2. `ButtonGroup.contentWidth` iterates `rowLayout.children`, which stays
   empty, so it evaluates to `0 + spacing * (0 - 1)` = **-5** and the group
   collapses to zero width.

In practice the translator's copy / web-search / paste / delete buttons render
overlapping each other, outside their container.

Every other `ButtonGroup` call site in the repo relies on the default property;
`TextCanvas.qml` is the only one that names `.data` explicitly.

### Fix

Alias to `actions.groupData`.

I also made `contentWidth` count only the children it actually sums. It
already skipped invisible children when totalling widths, but still used the
full `children.length` for spacing, so spacing was over-counted whenever a
child was hidden — and the empty case produced a negative width. Both are now
handled by tracking a `shown` counter.

### Testing

Verified on Hyprland 0.56.2 / CachyOS: the translator action buttons now lay
out in a row inside the group, and the group takes its correct width.
