### PR TITLE
fix(ai): drop call to addUserModels(), which does not exist

### DIFF
--- a/dots/.config/quickshell/ii/services/Ai.qml
+++ b/dots/.config/quickshell/ii/services/Ai.qml
@@ -391,7 +391,6 @@ Singleton {
 
     Component.onCompleted: {
         setModel(currentModelId, false, false); // Do necessary setup for model
-        root.addUserModels() // Config onReadyChanged above might not fire if config is loaded before this service
     }
 
     function guessModelLogo(model) {


### PR DESCRIPTION
### Problem

`services/Ai.qml:394`:

```qml
Component.onCompleted: {
    setModel(currentModelId, false, false); // Do necessary setup for model
    root.addUserModels() // Config onReadyChanged above might not fire if config is loaded before this service
}
```

`addUserModels` is not defined anywhere in the repository — `grep -rn
'addUserModels'` matches only this call site. Calling `undefined` as a
function throws a `TypeError`, and an exception thrown inside
`Component.onCompleted` aborts the remainder of that handler.

So every shell start logs a TypeError from this service. It looks like a
leftover from a feature that was removed or never landed.

### Fix

Remove the call. Nothing follows it in the handler today, so this changes no
behaviour beyond silencing the error.

If the intent was to load user-defined models from config and the function was
lost in a refactor, then this should instead be a re-implementation — happy to
take that direction if you know what it was supposed to do.
