### PR TITLE
fix(weather): label imperial units correctly

### DIFF
--- a/dots/.config/quickshell/ii/services/Weather.qml
+++ b/dots/.config/quickshell/ii/services/Weather.qml
@@ -62,8 +62,8 @@ Singleton {
         if (root.useUSCS) {
             temp.wind = (data?.current?.windspeedMiles || 0) + " mph";
             temp.precip = (data?.current?.precipInches || 0) + " in";
-            temp.visib = (data?.current?.visibilityMiles || 0) + " m";
-            temp.press = (data?.current?.pressureInches || 0) + " psi";
+            temp.visib = (data?.current?.visibilityMiles || 0) + " mi";
+            temp.press = (data?.current?.pressureInches || 0) + " inHg";
             temp.temp += (data?.current?.temp_F || 0);
             temp.tempFeelsLike += (data?.current?.FeelsLikeF || 0);
             temp.temp += "°F";


### PR DESCRIPTION
### Problem

`services/Weather.qml`, in the `useUSCS` branch of `refineData()`:

```qml
temp.visib = (data?.current?.visibilityMiles || 0) + " m";
temp.press = (data?.current?.pressureInches || 0) + " psi";
```

Both labels name the wrong unit:

- The value comes from `visibilityMiles` and is in **miles**, but is labelled
  `m` (metres).
- The value comes from `pressureInches` and is **inches of mercury**, but is
  labelled `psi`. Those are different units — standard pressure is about
  29.9 inHg versus about 14.7 psi, so the displayed number is off by roughly a
  factor of two for anyone reading it as psi.

The metric branch directly above is labelled correctly (`km`, `hPa`), so this
only affects users who enable US customary units.

### Fix

Use `mi` and `inHg`.
