### PR TITLE
fix(hypridle): use Lua dispatcher syntax for the remaining legacy calls

### DIFF
--- a/dots/.config/hypr/hypridle.conf
+++ b/dots/.config/hypr/hypridle.conf
@@ -5,7 +5,7 @@ $suspend_cmd = systemctl suspend || loginctl suspend
 general {
     lock_cmd = $lock_cmd
     before_sleep_cmd = loginctl lock-session
-    after_sleep_cmd = hyprctl dispatch global quickshell:lockFocus
+    after_sleep_cmd = hyprctl dispatch 'hl.dsp.global("quickshell:lockFocus")'
     inhibit_sleep = 3
 }
 
@@ -16,8 +16,8 @@ listener {
 
 listener {
     timeout = 600 # 10mins
-    on-timeout = hyprctl dispatch dpms off
-    on-resume = hyprctl dispatch dpms on
+    on-timeout = hyprctl dispatch 'hl.dsp.dpms({ action = "disable" })'
+    on-resume = hyprctl dispatch 'hl.dsp.dpms({ action = "enable" })'
 }
 
 listener {


### PR DESCRIPTION
### Problem

`dots/.config/hypr/hypridle.conf` mixes two dispatcher syntaxes. Line 1 already
uses the Lua form:

```
$lock_cmd = hyprctl dispatch 'hl.dsp.global("quickshell:lock")' & ...
```

but three calls were left on the old hyprlang syntax:

```
after_sleep_cmd = hyprctl dispatch global quickshell:lockFocus
on-timeout      = hyprctl dispatch dpms off
on-resume       = hyprctl dispatch dpms on
```

Current Hyprland parses `hyprctl dispatch` arguments as Lua, so all three fail.
Verified on Hyprland 0.56.2:

```
$ hyprctl dispatch dpms on
error: [string "return hl.dispatch(dpms on)"]:1: ')' expected near 'on'
 → Note: dispatch in lua is a shorthand for hl.dispatch(...), your syntax might need to be updated.

$ hyprctl dispatch global quickshell:lockFocus
error: [string "return hl.dispatch(global quickshell:lockFocu..."]:1: ')' expected near 'quickshell'

$ hyprctl dispatch 'hl.dsp.dpms({ action = "enable" })'
ok
```

The user-visible effect is that the 10-minute DPMS blank never fires, the
display never comes back via the resume hook, and the lock screen does not
gain focus after sleep.

### Fix

Convert the three remaining calls to the Lua form.

Note that upstream illogical-impulse already ships the Lua form on all three of
these lines — this fork appears to have simply not picked up that change, so
this is really a re-sync rather than a novel fix.

### Testing

Verified on Hyprland 0.56.2 / CachyOS. I have been running exactly these three
lines locally; the DPMS timeout and the post-sleep lock focus both work again.
