### PR TITLE
fix(weather cards): stop titles and day labels overflowing their cells

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/bar/cards/InDayForecast.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/cards/InDayForecast.qml
@@ -40,7 +40,13 @@ SectionCard {
                     spacing: 4
 
                     StyledText {
-                        Layout.alignment: Qt.AlignHCenter
+                        // Six cards share one row, so the cell can be narrower
+                        // than the day name. A RowLayout clamps the centering
+                        // offset at zero rather than shrinking the child, so
+                        // without fillWidth an oversized label spills out.
+                        Layout.fillWidth: true
+                        horizontalAlignment: Text.AlignHCenter
+                        elide: Text.ElideRight
                         text: root.getDayName(modelData.date, index)
                         font.pixelSize: Appearance.font.pixelSize.small
                         font.weight: Font.Bold
@@ -50,7 +56,8 @@ SectionCard {
                     MaterialShape {
                         Layout.alignment: Qt.AlignHCenter
                         shapeString: index === 0 ? "Cookie9Sided" : (index === 1 ? "Flower" : "Clover4Leaf")
-                        implicitSize: 48
+                        // Clamp to the cell so the shape cannot overflow it
+                        implicitSize: Math.max(24, Math.min(48, dayCard.width - dayColumn.anchors.margins * 2))
                         color: Qt.rgba(dayCard.textColor.r, dayCard.textColor.g, dayCard.textColor.b, 0.15)
 
                         MaterialSymbol {

--- a/dots/.config/quickshell/ii/modules/ii/bar/cards/SectionCard.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/cards/SectionCard.qml
@@ -60,6 +60,9 @@ Rectangle {
             StyledText {
                 id: titleText
                 Layout.fillWidth: true
+                // fillWidth lets this shrink below its implicit width, and
+                // without eliding it keeps painting over headerExtraContainer.
+                elide: Text.ElideRight
                 font.family: Appearance.font.family.title
                 font.pixelSize: Appearance.font.pixelSize.large
                 font.weight: Font.Bold


### PR DESCRIPTION
### Problem

Two related overflow bugs in the weather cards.

**1. `SectionCard.qml` — long titles paint over the header extras**

```qml
StyledText {
    id: titleText
    Layout.fillWidth: true
    ...
}
```

`Layout.fillWidth` gives the item a `Layout.minimumWidth` of 0, so the
RowLayout will happily squeeze it below its implicit width. With no `elide`
set, `Text` keeps painting past its own bounds and overlaps
`headerExtraContainer` to its right.

**2. `InDayForecast.qml` — day labels and shapes spill out of their cell**

```qml
StyledText {
    Layout.alignment: Qt.AlignHCenter
    text: root.getDayName(modelData.date, index)
    ...
}
```

`Layout.alignment` without `Layout.fillWidth` means the label keeps its full
implicit width. A RowLayout clamps the centering offset at zero rather than
shrinking the child, so a label wider than the cell spills out of the card
instead of centering within it.

The `MaterialShape` in the same cell hardcodes `implicitSize: 48`, in a cell
that is only around 50px wide once six day cards share a single row.

Both are most visible in non-English locales, since the day names and titles go
through `Translation.tr()` and tend to run longer than the English originals,
and at smaller popup widths in any language.

### Fix

- `SectionCard`: add `elide: Text.ElideRight` to the title.
- `InDayForecast`: give the day label `Layout.fillWidth` plus
  `horizontalAlignment` and `elide`, so it centres within the cell and
  truncates instead of overflowing.
- `InDayForecast`: clamp the shape to the available cell width
  (`Math.max(24, Math.min(48, ...))`), keeping 48 whenever there is room.

### Scope

Layout correctness only. I run a few cosmetic changes to these files locally
(tighter spacing, no primary/secondary/tertiary colour cycling, a smaller text
size) and deliberately left all of that out — it is personal taste, not a fix.

### Testing

Verified on Hyprland 0.56.2 / CachyOS with a Russian locale, where the day
abbreviations are wider than the English three-letter ones.
